### PR TITLE
Muritadhor

### DIFF
--- a/hackathon/models.py
+++ b/hackathon/models.py
@@ -14,7 +14,7 @@ class Hackathon(models.Model):
     start_date = models.DateField(null=False, blank=False)
     visibility = models.BooleanField(default=False, null=False)
     end_date = models.DateField(null=False, blank=False)
-    judges = models.ManyToManyField('accounts.User', related_name='hackathons_as_judge', blank=True)
+    judges = models.ManyToManyField('accounts.User', related_name='judged_hackathons', blank=True)
     min_team_size = models.IntegerField('minimum team size', null=False, default=1, validators=[MinValueValidator(1), MaxValueValidator(100)])
     max_team_size = models.IntegerField('maximum team size', null=False, default=5, validators=[MinValueValidator(1), MaxValueValidator(100)])
     organization = models.ForeignKey('organization.Organization', related_name='hackathons', null=True, on_delete=models.SET_NULL)

--- a/organization/models.py
+++ b/organization/models.py
@@ -1,10 +1,9 @@
 from django.db import models
 
-# Create your models here.
 class Organization(models.Model):
-    name = models.CharField(max_length=50, null=False, blank=False)
-    description = models.TextField(null=False, blank=False)
-    organizer = models.OneToOneField('accounts.User', related_name='organization', blank=True, null=True, on_delete=models.SET_NULL)
+    name = models.CharField(max_length=100, unique=True)
+    description = models.TextField()
+    organizer = models.OneToOneField('accounts.User', related_name='organization', on_delete=models.SET_NULL, null=True)
     moderators = models.ManyToManyField('accounts.User', related_name='moderating_organization', blank=True)
     is_approved = models.BooleanField(default=False)
     created_at = models.DateTimeField(auto_now_add=True)

--- a/organization/serializers.py
+++ b/organization/serializers.py
@@ -3,99 +3,104 @@ from .models import Organization
 from accounts.models import User
 
 class OrganizationSerializer(serializers.ModelSerializer):
-    class CreateOrganizationSerializer(serializers.ModelSerializer):
-        class Meta:
-            model = Organization
-            fields = ['name', 'description']
+    organizer = serializers.CharField(source='organizer.username', read_only=True)
+    moderators = serializers.SlugRelatedField(many=True, slug_field='username', queryset=User.objects.all(), required=False)
 
-        def validate(self, data):
-            request = self.context.get('request')
-            if not request:
-                raise serializers.ValidationError("Request context is required.")
-            
-            user = request.user
-            if Organization.objects.filter(organizer=user).exists():
-                raise serializers.ValidationError("You already have an existing organization.")
-            
-            if not data.get('name'):
-                raise serializers.ValidationError("Name is required.")
-            if not data.get('description'):
-                raise serializers.ValidationError("Description is required.")
-            
-            return data
-        
-        def create(self, validated_data):
-            request = self.context.get('request')
-            user = request.user
-            organization = Organization.objects.create(
-                name=validated_data['name'],
-                description=validated_data['description'],
-                organizer=user,
+    class Meta:
+        model = Organization
+        fields = ['id', 'name', 'description', 'organizer', 'moderators', 'is_approved', 'created_at', 'updated_at']
+        read_only_fields = ['id', 'is_approved', 'created_at', 'updated_at']
+
+class CreateOrganizationSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Organization
+        fields = ['name', 'description']
+
+    def validate(self, data):
+        if not self.context.get('request'):
+            raise serializers.ValidationError("Request context is required.")
+        user = self.context['request'].user
+        if Organization.objects.filter(organizer=user).exists():
+            raise serializers.ValidationError("You already have an organization.")
+        if not data.get('name').strip():
+            raise serializers.ValidationError("Name cannot be empty.")
+        if not data.get('description').strip():
+            raise serializers.ValidationError("Description cannot be empty.")
+        return data
+
+    def create(self, validated_data):
+        user = self.context['request'].user
+        organization = Organization.objects.create(
+            **validated_data,
+            organizer=user
+        )
+        # Send email notification
+        from django.core.mail import send_mail
+        send_mail(
+            subject='Organization Created',
+            message=f'Your organization "{organization.name}" has been created and is pending admin approval.',
+            from_email='noreply@hackathon.com',
+            recipient_list=[user.email],
+            fail_silently=True
+        )
+        return organization
+
+class UpdateOrganizationSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Organization
+        fields = ['name', 'description']
+        extra_kwargs = {'name': {'required': False}, 'description': {'required': False}}
+
+    def validate(self, data):
+        user = self.context['request'].user
+        if self.instance.organizer != user:
+            raise serializers.ValidationError("You are not authorized to update this organization.")
+        return data
+
+class AddModeratorSerializer(serializers.Serializer):
+    moderators = serializers.SlugRelatedField(many=True, slug_field='username', queryset=User.objects.all())
+
+    def validate(self, data):
+        user = self.context['request'].user
+        if self.instance.organizer != user:
+            raise serializers.ValidationError("Only the organizer can add moderators.")
+        return data
+
+    def update(self, instance, validated_data):
+        moderators = validated_data.get('moderators', [])
+        instance.moderators.add(*moderators)
+        # Send email to new moderators
+        from django.core.mail import send_mail
+        for moderator in moderators:
+            send_mail(
+                subject='Added as Moderator',
+                message=f'You have been added as a moderator for "{instance.name}".',
+                from_email='noreply@hackathon.com',
+                recipient_list=[moderator.email],
+                fail_silently=True
             )
-            organization.moderators.set(validated_data.get('moderators', []))
-            return organization
+        return instance
 
-    class OrganizationSerializer(serializers.ModelSerializer):
-        id = serializers.IntegerField(read_only=True)
-        name = serializers.CharField(read_only=True)
-        description = serializers.CharField(read_only=True)
-        organizer = serializers.CharField(read_only=True)
-        moderators = serializers.SlugRelatedField(many=True, slug_field='username', queryset=User.objects.all())
-        is_approved = serializers.BooleanField(read_only=True)
-        created_at = serializers.DateTimeField(read_only=True)
-        updated_at = serializers.DateTimeField(read_only=True)
+class RemoveModeratorSerializer(serializers.Serializer):
+    moderators = serializers.SlugRelatedField(many=True, slug_field='username', queryset=User.objects.all())
 
-        class Meta:
-            model = Organization
-            fields = '__all__'
+    def validate(self, data):
+        user = self.context['request'].user
+        if self.instance.organizer != user:
+            raise serializers.ValidationError("Only the organizer can remove moderators.")
+        return data
 
-    class AddModeratorSerializer(serializers.ModelSerializer):
-        class Meta:
-            model = Organization
-            fields = ['moderators']
-
-        def validate(self, data):
-            request = self.context.get('request')
-            if not request:
-                raise serializers.ValidationError("Request context is required.")
-            
-            user = request.user
-            organization = self.instance
-            if organization.organizer != user:
-                raise serializers.ValidationError("You are not authorized to add moderators to this organization.")
-            
-            return data
-
-        def update(self, instance, validated_data):
-            moderators = validated_data.get('moderators', [])
-            instance.moderators.add(moderators)
-            return instance
-        
-    class UpdateOrganizationSerializer(serializers.ModelSerializer):
-        class Meta:
-            model = Organization
-            fields = ['name', 'description']
-            extra_kwargs = {
-                'name': {'required': False},
-                'description': {'required': False},
-            }
-            
-
-        def validate(self, data):
-            request = self.context.get('request')
-            if not request:
-                raise serializers.ValidationError("Request context is required.")
-            
-            user = request.user
-            organization = self.instance
-            if organization.organizer != user:
-                raise serializers.ValidationError("You are not authorized to update this organization.")
-            
-            return data
-
-        def update(self, instance, validated_data):
-            instance.name = validated_data.get('name', instance.name)
-            instance.description = validated_data.get('description', instance.description)
-            instance.save()
-            return instance
-        
+    def update(self, instance, validated_data):
+        moderators = validated_data.get('moderators', [])
+        instance.moderators.remove(*moderators)
+        # Send email to removed moderators
+        from django.core.mail import send_mail
+        for moderator in moderators:
+            send_mail(
+                subject='Removed as Moderator',
+                message=f'You have been removed as a moderator for "{instance.name}".',
+                from_email='noreply@hackathon.com',
+                recipient_list=[moderator.email],
+                fail_silently=True
+            )
+        return instance

--- a/organization/urls.py
+++ b/organization/urls.py
@@ -1,11 +1,18 @@
 from django.urls import path
-from .views import CreateOrganizationView, AddModeratorView, ApproveOrganizationView, GetOrganizationsView, GetOrganizationView, UpdateOrganizationView
+from .views import (
+    CreateOrganizationView, UpdateOrganizationView, DeleteOrganizationView,
+    GetOrganizationView, GetOrganizationsView, GetUnapprovedOrganizationsView,
+    ApproveOrganizationView, AddModeratorView, RemoveModeratorView
+)
 
 urlpatterns = [
-    path('create', CreateOrganizationView.as_view(), name='create_organization'),
-    path('get', GetOrganizationsView.as_view(), name='get_organizations'),
-    path('get/<int:organization_id>', GetOrganizationView.as_view(), name='get_organization'),
-    path('add-moderator/<int:organization_id>', AddModeratorView.as_view(), name='add_moderator'),
-    path('approve/<int:organization_id>', ApproveOrganizationView.as_view(), name='approve_organization'),
-    path('update/<int:organization_id>', UpdateOrganizationView.as_view(), name='update_organization'),
+    path('create/', CreateOrganizationView.as_view(), name='create_organization'),
+    path('update/<int:organization_id>/', UpdateOrganizationView.as_view(), name='update_organization'),
+    path('delete/<int:organization_id>/', DeleteOrganizationView.as_view(), name='delete_organization'),
+    path('get/<int:organization_id>/', GetOrganizationView.as_view(), name='get_organization'),
+    path('get-all/', GetOrganizationsView.as_view(), name='get_organizations'),
+    path('get-unapproved/', GetUnapprovedOrganizationsView.as_view(), name='get_unapproved_organizations'),
+    path('approve/<int:organization_id>/', ApproveOrganizationView.as_view(), name='approve_organization'),
+    path('add-moderator/<int:organization_id>/', AddModeratorView.as_view(), name='add_moderator'),
+    path('remove-moderator/<int:organization_id>/', RemoveModeratorView.as_view(), name='remove_moderator'),
 ]

--- a/organization/views.py
+++ b/organization/views.py
@@ -3,99 +3,37 @@ from rest_framework.response import Response
 from rest_framework.generics import GenericAPIView
 from rest_framework.permissions import IsAuthenticated
 from accounts.permissions import IsOrganizer, IsAdmin
-from .serializers import OrganizationSerializer
+from .serializers import (
+    OrganizationSerializer, CreateOrganizationSerializer,
+    UpdateOrganizationSerializer, AddModeratorSerializer,
+    RemoveModeratorSerializer
+)
 from .models import Organization
 from drf_yasg.utils import swagger_auto_schema
 
-# Create your views here.
-
 class CreateOrganizationView(GenericAPIView):
-    serializer_class = OrganizationSerializer.CreateOrganizationSerializer
+    serializer_class = CreateOrganizationSerializer
     permission_classes = [IsAuthenticated]
+
     @swagger_auto_schema(
         request_body=serializer_class,
-        responses={201: 'Organization created successfully', 400: 'Bad Request'},
+        responses={201: OrganizationSerializer, 400: 'Bad Request'},
         operation_description="Create a new organization.",
         tags=['organization']
     )
     def post(self, request):
-        serializer = self.serializer_class(data=request.data, context={'request': request})
-        if serializer.is_valid(raise_exception=True):
-            organization = serializer.save()
-            return Response({'organization': OrganizationSerializer.OrganizationSerializer(organization).data}, status=status.HTTP_201_CREATED)
-        return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
-    
-class AddModeratorView(GenericAPIView):
-    serializer_class = OrganizationSerializer.AddModeratorSerializer
-    permission_classes = [IsAuthenticated, IsOrganizer]
-    @swagger_auto_schema(
-        request_body=serializer_class,
-        responses={200: 'Moderator added successfully', 400: 'Bad Request'},
-        operation_description="Add a moderator to an organization.",
-        tags=['organization']
-    )
-    def post(self, request, organization_id):
-        try:
-            organization = Organization.objects.get(id=organization_id)
-        except Organization.DoesNotExist:
-            return Response({'error': 'Organization does not exist.'}, status=status.HTTP_404_NOT_FOUND)
-        serializer = self.serializer_class(organization, data=request.data, context={'request': request})
-        if serializer.is_valid(raise_exception=True):
-            serializer.save()
-            return Response({'organization': OrganizationSerializer.OrganizationSerializer(organization).data}, status=status.HTTP_200_OK)
-        return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
-    
-class GetOrganizationsView(GenericAPIView):
-    permission_classes = [IsAuthenticated]
-    @swagger_auto_schema(
-        responses={200: 'Organizations retrieved successfully', 400: 'Bad Request'},
-        operation_description="Get all organizations.",
-        tags=['organization']
-    )
-    def get(self, request):
-        organizations = Organization.objects.all()
-        return Response({'organizations': OrganizationSerializer.OrganizationSerializer(organizations, many=True).data}, status=status.HTTP_200_OK)
-    
-class GetOrganizationView(GenericAPIView):
-    permission_classes = [IsAuthenticated]
-    @swagger_auto_schema(
-        responses={200: 'Organization retrieved successfully', 400: 'Bad Request'},
-        operation_description="Get an organization.",
-        tags=['organization']
-    )
-    def get(self, request, organization_id):
-        try:
-            organization = Organization.objects.get(id=organization_id)
-        except Organization.DoesNotExist:
-            return Response({'error': 'Organization does not exist.'}, status=status.HTTP_404_NOT_FOUND)
-        return Response({'organization': OrganizationSerializer.OrganizationSerializer(organization).data}, status=status.HTTP_200_OK)
-    
-class ApproveOrganizationView(GenericAPIView):
-    permission_classes = [IsAuthenticated, IsAdmin]
-    serializer_class = OrganizationSerializer.OrganizationSerializer
-    @swagger_auto_schema(
-        responses={200: 'Organization approved successfully', 400: 'Bad Request'},
-        operation_description="Approve an organization.",
-        tags=['organization']
-    )
-    def post(self, request, organization_id):
-        try:
-            organization = Organization.objects.get(id=organization_id)
-        except Organization.DoesNotExist:
-            return Response({'error': 'Organization does not exist.'}, status=status.HTTP_404_NOT_FOUND)
-        organization.is_approved = True
-        organization.save()
-        organizer = organization.organizer
-        organizer.is_organizer = True
-        organizer.save()
-        return Response({'organization': OrganizationSerializer.OrganizationSerializer(organization).data}, status=status.HTTP_200_OK)
-    
+        serializer = self.get_serializer(data=request.data, context={'request': request})
+        serializer.is_valid(raise_exception=True)
+        organization = serializer.save()
+        return Response(OrganizationSerializer(organization).data, status=status.HTTP_201_CREATED)
+
 class UpdateOrganizationView(GenericAPIView):
-    serializer_class = OrganizationSerializer.UpdateOrganizationSerializer
-    permission_classes = [IsAuthenticated]
+    serializer_class = UpdateOrganizationSerializer
+    permission_classes = [IsAuthenticated, IsOrganizer]
+
     @swagger_auto_schema(
         request_body=serializer_class,
-        responses={200: 'Organization updated successfully', 400: 'Bad Request'},
+        responses={200: OrganizationSerializer, 404: 'Not Found'},
         operation_description="Update an organization.",
         tags=['organization']
     )
@@ -103,23 +41,135 @@ class UpdateOrganizationView(GenericAPIView):
         try:
             organization = Organization.objects.get(id=organization_id)
         except Organization.DoesNotExist:
-            return Response({'error': 'Organization does not exist.'}, status=status.HTTP_404_NOT_FOUND)
-        serializer = self.serializer_class(organization, data=request.data, context={'request': request})
-        if serializer.is_valid(raise_exception=True):
-            serializer.save()
-            return Response({'organization': OrganizationSerializer.OrganizationSerializer(organization).data}, status=status.HTTP_200_OK)
-        return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
-    
+            return Response({'error': 'Organization not found.'}, status=status.HTTP_404_NOT_FOUND)
+        serializer = self.get_serializer(organization, data=request.data, context={'request': request})
+        serializer.is_valid(raise_exception=True)
+        organization = serializer.save()
+        return Response(OrganizationSerializer(organization).data)
+
 class DeleteOrganizationView(GenericAPIView):
-    permission_classes = [IsAuthenticated]
+    permission_classes = [IsAuthenticated, IsOrganizer]
+
     @swagger_auto_schema(
-        responses={204: 'Organization deleted successfully', 400: 'Bad Request'},
+        responses={204: 'No Content', 403: 'Forbidden', 404: 'Not Found'},
         operation_description="Delete an organization.",
         tags=['organization']
     )
     def delete(self, request, organization_id):
-        organization = Organization.objects.get(id=organization_id)
+        try:
+            organization = Organization.objects.get(id=organization_id)
+        except Organization.DoesNotExist:
+            return Response({'error': 'Organization not found.'}, status=status.HTTP_404_NOT_FOUND)
         if organization.organizer != request.user:
-            return Response({'error': 'You are not authorized to delete this organization.'}, status=status.HTTP_403_FORBIDDEN)
+            return Response({'error': 'Not authorized.'}, status=status.HTTP_403_FORBIDDEN)
         organization.delete()
         return Response(status=status.HTTP_204_NO_CONTENT)
+
+class GetOrganizationView(GenericAPIView):
+    permission_classes = [IsAuthenticated]
+
+    @swagger_auto_schema(
+        responses={200: OrganizationSerializer, 404: 'Not Found'},
+        operation_description="Retrieve an organization by ID.",
+        tags=['organization']
+    )
+    def get(self, request, organization_id):
+        try:
+            organization = Organization.objects.get(id=organization_id)
+        except Organization.DoesNotExist:
+            return Response({'error': 'Organization not found.'}, status=status.HTTP_404_NOT_FOUND)
+        return Response(OrganizationSerializer(organization).data)
+
+class GetOrganizationsView(GenericAPIView):
+    permission_classes = [IsAuthenticated]
+
+    @swagger_auto_schema(
+        responses={200: OrganizationSerializer(many=True)},
+        operation_description="Retrieve all organizations.",
+        tags=['organization']
+    )
+    def get(self, request):
+        organizations = Organization.objects.all()
+        return Response(OrganizationSerializer(organizations, many=True).data)
+
+class GetUnapprovedOrganizationsView(GenericAPIView):
+    permission_classes = [IsAuthenticated, IsAdmin]
+
+    @swagger_auto_schema(
+        responses={200: OrganizationSerializer(many=True)},
+        operation_description="Retrieve all unapproved organizations.",
+        tags=['organization']
+    )
+    def get(self, request):
+        organizations = Organization.objects.filter(is_approved=False)
+        return Response(OrganizationSerializer(organizations, many=True).data)
+
+class ApproveOrganizationView(GenericAPIView):
+    permission_classes = [IsAuthenticated, IsAdmin]
+
+    @swagger_auto_schema(
+        responses={200: OrganizationSerializer, 404: 'Not Found'},
+        operation_description="Approve an organization.",
+        tags=['organization']
+    )
+    def post(self, request, organization_id):
+        try:
+            organization = Organization.objects.get(id=organization_id)
+        except Organization.DoesNotExist:
+            return Response({'error': 'Organization not found.'}, status=status.HTTP_404_NOT_FOUND)
+        organization.is_approved = True
+        organization.save()
+        organizer = organization.organizer
+        if organizer:
+            organizer.is_organizer = True
+            organizer.save()
+            # Send approval email
+            from django.core.mail import send_mail
+            send_mail(
+                subject='Organization Approved',
+                message=f'Your organization "{organization.name}" has been approved.',
+                from_email='noreply@hackathon.com',
+                recipient_list=[organizer.email],
+                fail_silently=True
+            )
+        return Response(OrganizationSerializer(organization).data)
+
+class AddModeratorView(GenericAPIView):
+    serializer_class = AddModeratorSerializer
+    permission_classes = [IsAuthenticated, IsOrganizer]
+
+    @swagger_auto_schema(
+        request_body=serializer_class,
+        responses={200: OrganizationSerializer, 404: 'Not Found'},
+        operation_description="Add moderators to an organization.",
+        tags=['organization']
+    )
+    def post(self, request, organization_id):
+        try:
+            organization = Organization.objects.get(id=organization_id)
+        except Organization.DoesNotExist:
+            return Response({'error': 'Organization not found.'}, status=status.HTTP_404_NOT_FOUND)
+        serializer = self.get_serializer(organization, data=request.data, context={'request': request})
+        serializer.is_valid(raise_exception=True)
+        organization = serializer.save()
+        return Response(OrganizationSerializer(organization).data)
+
+class RemoveModeratorView(GenericAPIView):
+    serializer_class = RemoveModeratorSerializer
+    permission_classes = [IsAuthenticated, IsOrganizer]
+
+    @swagger_auto_schema(
+        request_body=serializer_class,
+        responses={200: OrganizationSerializer, 404: 'Not Found'},
+        operation_description="Remove moderators from an organization.",
+        tags=['organization']
+    )
+    def post(self, request, organization_id):
+        try:
+            organization = Organization.objects.get(id=organization_id)
+        except Organization.DoesNotExist:
+            return Response({'error': 'Organization not found.'}, status=status.HTTP_404_NOT_FOUND)
+        serializer = self.get_serializer(organization, data=request.data, context={'request': request})
+        serializer.is_valid(raise_exception=True)
+        organization = serializer.save()
+        return Response(OrganizationSerializer(organization).data)


### PR DESCRIPTION
This pull request introduces significant updates to the `organization` app, including model enhancements, serializer improvements, and new API endpoints for managing organizations and moderators. The changes aim to improve data validation, streamline functionality, and enhance user feedback through email notifications.

### Model Enhancements:
* Updated the `Organization` model to include a unique constraint on the `name` field, increased its max length to 100, and made the `description` field optional. These changes improve data integrity and flexibility. (`organization/models.py`)

### Serializer Improvements:
* Added new serializers (`OrganizationSerializer`, `UpdateOrganizationSerializer`, `AddModeratorSerializer`, and `RemoveModeratorSerializer`) to improve validation and modularize functionality. These include stricter checks for empty fields and user permissions. (`organization/serializers.py`)
* Integrated email notifications for key actions such as organization creation, moderator addition/removal, and organization approval. This enhances user experience and communication. (`organization/serializers.py`)

### API Enhancements:
* Introduced new endpoints for deleting organizations, retrieving unapproved organizations, and managing moderators (add/remove). Updated existing endpoints to provide more descriptive responses and align with RESTful conventions. (`organization/urls.py`, `organization/views.py`) [[1]](diffhunk://#diff-75703c53fd931e49d3e6f03a7d017b4cf820c890273ed342a6b0082ce338d4d9L2-R17) [[2]](diffhunk://#diff-5bc0e76ea90434a463e50ec9c0bac06c46359491ffe173ec720d3e528a7c7e4aL6-R175)
* Enhanced Swagger documentation for all endpoints to improve API usability and clarity. (`organization/views.py`)

### Code Refactoring:
* Refactored serializers and views to remove redundant code, improve readability, and ensure DRY principles. Examples include consolidating validation logic and using `get_serializer` for consistency. (`organization/serializers.py`, `organization/views.py`) [[1]](diffhunk://#diff-754772c65463030ff0fcbdf97001c3bc2ecd87a0aa07ef8e75c1f42c1146958dR6-L101) [[2]](diffhunk://#diff-5bc0e76ea90434a463e50ec9c0bac06c46359491ffe173ec720d3e528a7c7e4aL6-R175)

### Minor Updates:
* Renamed the `judges` field in the `Hackathon` model to use a more intuitive `related_name` for reverse lookups. (`hackathon/models.py`)