### PR TITLE
Muritadhor

### DIFF
--- a/hackathon/models.py
+++ b/hackathon/models.py
@@ -76,7 +76,12 @@ class Submission(models.Model):
 class Review(models.Model):
     submission = models.ForeignKey(Submission, related_name='reviews', on_delete=models.CASCADE)
     judge = models.ForeignKey('accounts.User', related_name='reviews', on_delete=models.CASCADE)
-    score = models.IntegerField(null=False, blank=False)
+    innovation_score = models.IntegerField(null=False, blank=False, default=0, validators=[MinValueValidator(0), MaxValueValidator(10)])
+    technical_score = models.IntegerField(null=False, blank=False, default=0, validators=[MinValueValidator(0), MaxValueValidator(10)])
+    user_experience_score = models.IntegerField(null=False, blank=False, default=0, validators=[MinValueValidator(0), MaxValueValidator(10)])
+    impact_score = models.IntegerField(null=False, blank=False, default=0, validators=[MinValueValidator(0), MaxValueValidator(10)])
+    presentation_score = models.IntegerField(null=False, blank=False, default=0, validators=[MinValueValidator(0), MaxValueValidator(10)])
+    overall_score = models.IntegerField(null=False, blank=False, default=0, validators=[MinValueValidator(0), MaxValueValidator(10)])
     review = models.TextField(null=True, blank=True)
     created_at = models.DateTimeField(auto_now_add=True)
     updated_at = models.DateTimeField(auto_now=True)

--- a/hackathon/urls.py
+++ b/hackathon/urls.py
@@ -4,7 +4,7 @@ from .views import (
     HackathonCreateView, HackathonListView, HackathonRetrieveView,
     RegisterForHackathonView, InviteJudgeView, ProjectViewSet,
     SubmissionViewSet, ReviewViewSet, PrizeViewSet, ThemeViewSet, RuleViewSet,
-    SubmitProjectView
+    SubmitProjectView, JudgeHackathonsView
 )
 
 router = DefaultRouter()
@@ -18,6 +18,7 @@ router.register(r'rules', RuleViewSet, basename='rule')
 urlpatterns = [
     path('', HackathonListView.as_view(), name='hackathon_list'),
     path('create/', HackathonCreateView.as_view(), name='hackathon_create'),
+    path('judge/hackathons/', JudgeHackathonsView.as_view(), name='judge_hackathons'),
     path('<int:hackathon_id>/', HackathonRetrieveView.as_view(), name='hackathon_retrieve'),
     path('<int:hackathon_id>/register/', RegisterForHackathonView.as_view(), name='hackathon_register'),
     path('<int:hackathon_id>/invite-judge/', InviteJudgeView.as_view(), name='hackathon_invite_judge'),

--- a/project/models.py
+++ b/project/models.py
@@ -7,6 +7,7 @@ class Project(models.Model):
     github_url = models.URLField("github url", blank=False)
     demo_video_url = models.URLField("Project video link", blank=True)
     live_link = models.URLField("Project live link", blank=True)
+    presentation_link = models.URLField("Project presentation link", blank=True)
     team = models.ForeignKey(Team, related_name='projects', null=True, on_delete=models.SET_NULL)
     created_at = models.DateTimeField(auto_now_add=True)
     updated_at = models.DateTimeField(auto_now=True)

--- a/project/models.py
+++ b/project/models.py
@@ -5,6 +5,7 @@ class Project(models.Model):
     title = models.CharField(max_length=100, null=False, blank=False)
     description = models.TextField(null=False, blank=False)
     github_url = models.URLField("github url", blank=False)
+    demo_video_url = models.URLField("Project video link", blank=True)
     live_link = models.URLField("Project live link", blank=True)
     team = models.ForeignKey(Team, related_name='projects', null=True, on_delete=models.SET_NULL)
     created_at = models.DateTimeField(auto_now_add=True)

--- a/project/serializers.py
+++ b/project/serializers.py
@@ -7,7 +7,7 @@ class ProjectSerializer:
     class CreateProjectSerializer(serializers.ModelSerializer):
         class Meta:
             model = Project
-            fields = ['title', 'description', 'github_url', 'live_link', 'team']
+            fields = ['title', 'description', 'github_url', 'live_link', 'demo_video_url', 'presentation_link', 'team']
             ref_name = 'ProjectCreateSerializer'
         
         def validate(self, data):
@@ -49,6 +49,8 @@ class ProjectSerializer:
                 description=validated_data['description'],
                 github_url=validated_data['github_url'],
                 live_link=validated_data.get('live_link', ''),
+                demo_video_url=validated_data.get('demo_video_url', ''),
+                presentation_link=validated_data.get('presentation_link', ''),
                 team=validated_data['team']
             )
             return project
@@ -58,7 +60,7 @@ class ProjectSerializer:
         
         class Meta:
             model = Project
-            fields = ['id', 'title', 'description', 'github_url', 'live_link', 'team', 'created_at', 'updated_at']
+            fields = ['id', 'title', 'description', 'github_url', 'live_link', 'demo_video_url', 'presentation_link', 'team', 'created_at', 'updated_at']
             read_only_fields = ['created_at', 'updated_at']
             ref_name = 'ProjectDetailSerializer'
         
@@ -73,12 +75,14 @@ class ProjectSerializer:
     class UpdateProjectSerializer(serializers.ModelSerializer):
         class Meta:
             model = Project
-            fields = ['title', 'description', 'github_url', 'live_link']
+            fields = ['title', 'description', 'github_url', 'live_link', 'demo_video_url', 'presentation_link']
             extra_kwargs = {
                 'title': {'required': False},
                 'description': {'required': False},
                 'github_url': {'required': False},
                 'live_link': {'required': False},
+                'demo_video_url': {'required': False},
+                'presentation_link': {'required': False},
             }
             ref_name = 'ProjectUpdateSerializer'
         
@@ -102,5 +106,7 @@ class ProjectSerializer:
             instance.description = validated_data.get('description', instance.description)
             instance.github_url = validated_data.get('github_url', instance.github_url)
             instance.live_link = validated_data.get('live_link', instance.live_link)
+            instance.demo_video_url = validated_data.get('demo_video_url', instance.demo_video_url)
+            instance.presentation_link = validated_data.get('presentation_link', instance.presentation_link)
             instance.save()
             return instance 


### PR DESCRIPTION
This pull request introduces enhancements to the hackathon application, focusing on scoring granularity for reviews, additional fields for project submissions, and a new view for judges to access their assigned hackathons. The changes improve data modeling, serialization, and API functionality.

### Scoring Enhancements for Reviews:
* Added detailed scoring fields (`innovation_score`, `technical_score`, `user_experience_score`, `impact_score`, `presentation_score`, `overall_score`) to the `Review` model, replacing the single `score` field. Validators ensure scores are between 0 and 10. (`hackathon/models.py`, [hackathon/models.pyL79-R84](diffhunk://#diff-170250a0140b5fd4684327ea296004d426d288f4678b7d529aaeaffa276fa0bbL79-R84))
* Updated `ReviewSerializer` to include the new scoring fields and validation logic for their range. (`hackathon/serializers.py`, [[1]](diffhunk://#diff-11734120d4f63f0c43eaf0c4390fa82c62fd60ecabaac1c96bb013dd6c9a9f99L214-L224) [[2]](diffhunk://#diff-11734120d4f63f0c43eaf0c4390fa82c62fd60ecabaac1c96bb013dd6c9a9f99R235-R239)
* Modified the `get_reviews` method to return the new scoring fields in serialized review data. (`hackathon/serializers.py`, [hackathon/serializers.pyL160-R167](diffhunk://#diff-11734120d4f63f0c43eaf0c4390fa82c62fd60ecabaac1c96bb013dd6c9a9f99L160-R167))

### Additional Fields for Project Submissions:
* Added `demo_video_url` and `presentation_link` fields to the `Project` model for richer project submissions. (`project/models.py`, [project/models.pyR8-R10](diffhunk://#diff-8378f35cbd9d52e55dca4bd71af0a9ad70bd54825e834f45daef168dccda1793R8-R10))
* Updated serializers (`ProjectSerializer`, `CreateProjectSerializer`, `UpdateProjectSerializer`) to handle the new fields, including validation and read/write logic. (`project/serializers.py`, [[1]](diffhunk://#diff-2155a442441c20c2d072cedecd058fe51818e38b17da0d38c0a693bc6a5ed282L10-R10) [[2]](diffhunk://#diff-2155a442441c20c2d072cedecd058fe51818e38b17da0d38c0a693bc6a5ed282R52-R53) [[3]](diffhunk://#diff-2155a442441c20c2d072cedecd058fe51818e38b17da0d38c0a693bc6a5ed282L61-R63) [[4]](diffhunk://#diff-2155a442441c20c2d072cedecd058fe51818e38b17da0d38c0a693bc6a5ed282L76-R85) [[5]](diffhunk://#diff-2155a442441c20c2d072cedecd058fe51818e38b17da0d38c0a693bc6a5ed282R109-R110)
* Adjusted `hackathon/serializers.py` to include the new fields in hackathon-related project serializers. (`hackathon/serializers.py`, [[1]](diffhunk://#diff-11734120d4f63f0c43eaf0c4390fa82c62fd60ecabaac1c96bb013dd6c9a9f99L58-R58) [[2]](diffhunk://#diff-11734120d4f63f0c43eaf0c4390fa82c62fd60ecabaac1c96bb013dd6c9a9f99L82-R95)

### New Judge-Specific View:
* Introduced `JudgeHackathonsView` to allow judges to retrieve a list of hackathons they are judging. Includes permission checks and API schema documentation. (`hackathon/views.py`, [hackathon/views.pyR418-R435](diffhunk://#diff-a45f953071c9f6dc1111be9e09751c9d65e16c40426d9ab1377b2143d3518a6fR418-R435))
* Added the corresponding URL route for the new view. (`hackathon/urls.py`, [[1]](diffhunk://#diff-df38932dc53aa8e511e2abf87a988b0b74d69de627c3654c8bd5c6b3ff8ea828L7-R7) [[2]](diffhunk://#diff-df38932dc53aa8e511e2abf87a988b0b74d69de627c3654c8bd5c6b3ff8ea828R21)