### PR TITLE
Added Submission deadline to Hackathon Field

### DIFF
--- a/hackathon/models.py
+++ b/hackathon/models.py
@@ -14,6 +14,7 @@ class Hackathon(models.Model):
     start_date = models.DateField(null=False, blank=False)
     visibility = models.BooleanField(default=False, null=False)
     end_date = models.DateField(null=False, blank=False)
+    submission_deadline = models.DateTimeField(null=False, blank=False)
     judges = models.ManyToManyField('accounts.User', related_name='judged_hackathons', blank=True)
     min_team_size = models.IntegerField('minimum team size', null=False, default=1, validators=[MinValueValidator(1), MaxValueValidator(100)])
     max_team_size = models.IntegerField('maximum team size', null=False, default=5, validators=[MinValueValidator(1), MaxValueValidator(100)])

--- a/hackathon/serializers.py
+++ b/hackathon/serializers.py
@@ -47,7 +47,7 @@ class SubmitProjectSerializer(serializers.Serializer):
             raise serializers.ValidationError("This project is already submitted to this hackathon.")
         if project.team not in hackathon.teams.all():
             raise serializers.ValidationError("Your team is not registered for this hackathon.")
-        if hackathon.end_date < timezone.now().date():
+        if hackathon.submission_deadline < timezone.now():
             raise serializers.ValidationError("Hackathon submission period has ended.")
         
         submission = Submission.objects.create(project=project, hackathon=hackathon, team=project.team)
@@ -191,7 +191,7 @@ class CreateHackathonSerializer(HackathonSerializer):
     prizes = serializers.JSONField(required=False, help_text='A JSON list of prize objects, e.g., [{"name": "1st Place", "amount": 1000}]')
 
     class Meta(HackathonSerializer.Meta):
-        fields = ['title', 'description', 'banner_image', 'visibility', 'venue', 'details', 'skills', 'themes', 'grand_prize', 'start_date', 'end_date', 'min_team_size', 'max_team_size', 'rules', 'prizes']
+        fields = ['title', 'description', 'banner_image', 'visibility', 'venue', 'details', 'skills', 'themes', 'grand_prize', 'start_date', 'end_date', 'submission_deadline', 'min_team_size', 'max_team_size', 'rules', 'prizes']
 
     def validate_prizes(self, value):
         if not isinstance(value, list):
@@ -210,6 +210,8 @@ class CreateHackathonSerializer(HackathonSerializer):
             raise serializers.ValidationError("Only organizers with an approved organization can create a hackathon.")
         if data.get('start_date') and data.get('end_date') and data['start_date'] > data['end_date']:
             raise serializers.ValidationError("Start date must be before end date.")
+        if data.get('end_date') and data.get('submission_deadline') and data['submission_deadline'].date() > data['end_date']:
+            raise serializers.ValidationError("Submission deadline must be before or on the end date.")
         if data.get('min_team_size') and data.get('max_team_size') and data['min_team_size'] > data['max_team_size']:
             raise serializers.ValidationError("Minimum team size cannot exceed maximum team size.")
         return data
@@ -231,7 +233,7 @@ class UpdateHackathonSerializer(HackathonSerializer):
     prizes = serializers.JSONField(required=False, help_text='A JSON list of prize objects, e.g., [{"name": "1st Place", "amount": 1000}]')
 
     class Meta(HackathonSerializer.Meta):
-        fields = ['title', 'description', 'banner_image', 'venue', 'details', 'skills', 'themes', 'grand_prize', 'start_date', 'end_date', 'min_team_size', 'max_team_size', 'visibility', 'rules', 'prizes']
+        fields = ['title', 'description', 'banner_image', 'venue', 'details', 'skills', 'themes', 'grand_prize', 'start_date', 'end_date', 'submission_deadline', 'min_team_size', 'max_team_size', 'visibility', 'rules', 'prizes']
         extra_kwargs = {field: {'required': False} for field in fields}
 
     def validate_prizes(self, value):
@@ -252,6 +254,8 @@ class UpdateHackathonSerializer(HackathonSerializer):
             raise serializers.ValidationError("You are not authorized to update this hackathon.")
         if data.get('start_date') and data.get('end_date') and data['start_date'] > data['end_date']:
             raise serializers.ValidationError("Start date must be before end date.")
+        if data.get('end_date') and data.get('submission_deadline') and data['submission_deadline'].date() > data['end_date']:
+            raise serializers.ValidationError("Submission deadline must be before or on the end date.")
         if data.get('min_team_size') and data.get('max_team_size') and data['min_team_size'] > data['max_team_size']:
             raise serializers.ValidationError("Minimum team size cannot exceed maximum team size.")
         return data


### PR DESCRIPTION
This pull request introduces a new `submission_deadline` field to the `Hackathon` model and updates related logic in serializers to ensure proper validation and usage. The changes aim to provide more granular control over submission deadlines, separate from the hackathon's end date.

### Model Updates:
* Added `submission_deadline` as a `DateTimeField` to the `Hackathon` model to specify the exact deadline for project submissions. (`hackathon/models.py`)

### Serializer Updates:
* Updated the `CreateHackathonSerializer` and `UpdateHackathonSerializer` to include the `submission_deadline` field in their `fields` list. (`hackathon/serializers.py`) [[1]](diffhunk://#diff-11734120d4f63f0c43eaf0c4390fa82c62fd60ecabaac1c96bb013dd6c9a9f99L194-R194) [[2]](diffhunk://#diff-11734120d4f63f0c43eaf0c4390fa82c62fd60ecabaac1c96bb013dd6c9a9f99L234-R236)
* Added validation to ensure that `submission_deadline` is on or before the `end_date` in both `CreateHackathonSerializer` and `UpdateHackathonSerializer`. (`hackathon/serializers.py`) [[1]](diffhunk://#diff-11734120d4f63f0c43eaf0c4390fa82c62fd60ecabaac1c96bb013dd6c9a9f99R213-R214) [[2]](diffhunk://#diff-11734120d4f63f0c43eaf0c4390fa82c62fd60ecabaac1c96bb013dd6c9a9f99R257-R258)
* Modified the submission logic in the `save` method to check against `submission_deadline` instead of `end_date`. (`hackathon/serializers.py`)