### PR TITLE
FEAT: Added endpoint to fetch all judges for an hackathon

### DIFF
--- a/hackathon/urls.py
+++ b/hackathon/urls.py
@@ -3,7 +3,8 @@ from rest_framework.routers import DefaultRouter
 from .views import (
     HackathonCreateView, HackathonListView, HackathonRetrieveView,
     RegisterForHackathonView, InviteJudgeView,
-    SubmissionViewSet, ReviewViewSet, ThemeViewSet, SubmitProjectView, JudgeHackathonsView
+    SubmissionViewSet, ReviewViewSet, ThemeViewSet, SubmitProjectView, JudgeHackathonsView,
+    HackathonJudgesView
 )
 
 router = DefaultRouter()
@@ -16,6 +17,7 @@ urlpatterns = [
     path('create/', HackathonCreateView.as_view(), name='hackathon_create'),
     path('judge/hackathons/', JudgeHackathonsView.as_view(), name='judge_hackathons'),
     path('<int:hackathon_id>/', HackathonRetrieveView.as_view(), name='hackathon_retrieve'),
+    path('<int:hackathon_id>/judges/', HackathonJudgesView.as_view(), name='hackathon_judges'),
     path('<int:hackathon_id>/register/', RegisterForHackathonView.as_view(), name='hackathon_register'),
     path('<int:hackathon_id>/invite-judge/', InviteJudgeView.as_view(), name='hackathon_invite_judge'),
     path('<int:hackathon_id>/submit-project/', SubmitProjectView.as_view(), name='project_submit'),


### PR DESCRIPTION
This pull request introduces a new feature to fetch all judges associated with a specific hackathon and integrates it into the `hackathon` app. The changes include adding a new view, updating the URL configuration, and importing the necessary serializer for the functionality.

### New Feature: Fetch Hackathon Judges

* **URL Configuration Update**: Added a new route `'<int:hackathon_id>/judges/'` to the `hackathon/urls.py` file for accessing the `HackathonJudgesView`. This route allows users to retrieve all judges for a specific hackathon. [[1]](diffhunk://#diff-df38932dc53aa8e511e2abf87a988b0b74d69de627c3654c8bd5c6b3ff8ea828L6-R7) [[2]](diffhunk://#diff-df38932dc53aa8e511e2abf87a988b0b74d69de627c3654c8bd5c6b3ff8ea828R20)
* **View Addition**: Introduced the `HackathonJudgesView` class in `hackathon/views.py`. This view handles GET requests to fetch all judges for a given hackathon, includes proper error handling for non-existent hackathons, and uses the `UserSerializer.RetrieveSerializer` for response serialization.
* **Serializer Import**: Imported `UserSerializer` from `accounts.serializers` in `hackathon/views.py` to enable serialization of judge data in the newly added view.