### PR TITLE
Add endpoint to fetch participants of a specific hackathon

### DIFF
--- a/hackathon/urls.py
+++ b/hackathon/urls.py
@@ -4,7 +4,7 @@ from .views import (
     HackathonCreateView, HackathonListView, HackathonRetrieveView,
     RegisterForHackathonView, InviteJudgeView,
     SubmissionViewSet, ReviewViewSet, ThemeViewSet, SubmitProjectView, JudgeHackathonsView,
-    HackathonJudgesView
+    HackathonJudgesView, HackathonParticipantsView
 )
 
 router = DefaultRouter()
@@ -18,6 +18,7 @@ urlpatterns = [
     path('judge/hackathons/', JudgeHackathonsView.as_view(), name='judge_hackathons'),
     path('<int:hackathon_id>/', HackathonRetrieveView.as_view(), name='hackathon_retrieve'),
     path('<int:hackathon_id>/judges/', HackathonJudgesView.as_view(), name='hackathon_judges'),
+    path('<int:hackathon_id>/participants/', HackathonParticipantsView.as_view(), name='hackathon_participants'),
     path('<int:hackathon_id>/register/', RegisterForHackathonView.as_view(), name='hackathon_register'),
     path('<int:hackathon_id>/invite-judge/', InviteJudgeView.as_view(), name='hackathon_invite_judge'),
     path('<int:hackathon_id>/submit-project/', SubmitProjectView.as_view(), name='project_submit'),


### PR DESCRIPTION
This pull request introduces a new feature to fetch participants (teams) for a specific hackathon and integrates it into the existing hackathon API. The most important changes include adding a new view for participants, updating the URL configuration, and importing the necessary serializer.

### New feature: Fetch hackathon participants

* **Added `HackathonParticipantsView` class**: This new API view allows authenticated users to retrieve all participants (teams) of a specific hackathon. It includes proper error handling for cases where the hackathon does not exist and uses `TeamSerializer` for the response. (`hackathon/views.py`, [hackathon/views.pyR389-R411](diffhunk://#diff-a45f953071c9f6dc1111be9e09751c9d65e16c40426d9ab1377b2143d3518a6fR389-R411))

### URL configuration updates

* **Updated `urlpatterns`**: Added a new URL pattern to map the `HackathonParticipantsView` to the endpoint `<hackathon_id>/participants/`. (`hackathon/urls.py`, [hackathon/urls.pyR21](diffhunk://#diff-df38932dc53aa8e511e2abf87a988b0b74d69de627c3654c8bd5c6b3ff8ea828R21))
* **Updated imports**: Included `HackathonParticipantsView` in the list of imported views. (`hackathon/urls.py`, [hackathon/urls.pyL7-R7](diffhunk://#diff-df38932dc53aa8e511e2abf87a988b0b74d69de627c3654c8bd5c6b3ff8ea828L7-R7))

### Serializer import

* **Imported `TeamSerializer`**: Added the `TeamSerializer` import to support serialization of hackathon participants in the new view. (`hackathon/views.py`, [hackathon/views.pyR17](diffhunk://#diff-a45f953071c9f6dc1111be9e09751c9d65e16c40426d9ab1377b2143d3518a6fR17))