### PR TITLE
Added new endpoints

### DIFF
--- a/hackathon/models.py
+++ b/hackathon/models.py
@@ -41,10 +41,17 @@ class Theme(models.Model):
         return self.name
 
 class Submission(models.Model):
+    STATUS_CHOICES = [
+        ('pending', 'Pending'),
+        ('reviewed', 'Reviewed'),
+        ('rejected', 'Rejected'),
+    ]
+    
     project = models.OneToOneField('project.Project', related_name='submission', on_delete=models.CASCADE)
     hackathon = models.ForeignKey(Hackathon, related_name='submissions', on_delete=models.CASCADE)
     team = models.ForeignKey('team.Team', related_name='submissions', on_delete=models.CASCADE)
     approved = models.BooleanField(default=False)
+    status = models.CharField(max_length=10, choices=STATUS_CHOICES, default='pending')
     created_at = models.DateTimeField(auto_now_add=True)
     updated_at = models.DateTimeField(auto_now=True)
 

--- a/hackathon/serializers.py
+++ b/hackathon/serializers.py
@@ -62,7 +62,7 @@ class SubmissionSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = Submission
-        fields = ['id', 'project', 'team', 'hackathon', 'approved', 'reviews', 'created_at', 'updated_at']
+        fields = ['id', 'project', 'team', 'hackathon', 'approved', 'status', 'reviews', 'created_at', 'updated_at']
         read_only_fields = ['created_at', 'updated_at', 'hackathon', 'project', 'team', 'reviews']
 
     def get_project(self, obj):
@@ -104,7 +104,7 @@ class CreateSubmissionSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = Submission
-        fields = ['project']
+        fields = ['project', 'status']
 
     def validate_project(self, value):
         from project.models import Project
@@ -135,9 +135,14 @@ class CreateSubmissionSerializer(serializers.ModelSerializer):
 class UpdateSubmissionSerializer(serializers.ModelSerializer):
     class Meta:
         model = Submission
-        fields = ['approved']
+        fields = ['approved', 'status']
 
     def validate_approved(self, value):
+        if not self.context['request'].user.is_organizer:
+            raise serializers.ValidationError("Only organizers can update submission status.")
+        return value
+    
+    def validate_status(self, value):
         if not self.context['request'].user.is_organizer:
             raise serializers.ValidationError("Only organizers can update submission status.")
         return value

--- a/hackathon/urls.py
+++ b/hackathon/urls.py
@@ -4,7 +4,7 @@ from .views import (
     HackathonCreateView, HackathonListView, HackathonRetrieveView,
     RegisterForHackathonView, InviteJudgeView,
     SubmissionViewSet, ReviewViewSet, ThemeViewSet, SubmitProjectView, JudgeHackathonsView,
-    HackathonJudgesView, HackathonParticipantsView
+    HackathonJudgesView, HackathonParticipantsView, OrganizerHackathonsView
 )
 
 router = DefaultRouter()
@@ -16,6 +16,7 @@ urlpatterns = [
     path('', HackathonListView.as_view(), name='hackathon_list'),
     path('create/', HackathonCreateView.as_view(), name='hackathon_create'),
     path('judge/hackathons/', JudgeHackathonsView.as_view(), name='judge_hackathons'),
+    path('organizer/hackathons/', OrganizerHackathonsView.as_view(), name='organizer_hackathons'),
     path('<int:hackathon_id>/', HackathonRetrieveView.as_view(), name='hackathon_retrieve'),
     path('<int:hackathon_id>/judges/', HackathonJudgesView.as_view(), name='hackathon_judges'),
     path('<int:hackathon_id>/participants/', HackathonParticipantsView.as_view(), name='hackathon_participants'),


### PR DESCRIPTION
This pull request introduces a new `status` field to the `Submission` model to track the state of submissions, updates related serializers to handle this field, and adds a new API endpoint for organizers to view their hackathons. The changes improve submission management and enhance organizer functionality.

### Submission Management Enhancements:
* **`hackathon/models.py`**: Added a `status` field to the `Submission` model with choices (`pending`, `reviewed`, `rejected`) and a default value of `pending`. This allows tracking the state of submissions.
* **`hackathon/serializers.py`**:
  - Updated `SubmissionSerializer`, `CreateSubmissionSerializer`, and `UpdateSubmissionSerializer` to include the `status` field. [[1]](diffhunk://#diff-11734120d4f63f0c43eaf0c4390fa82c62fd60ecabaac1c96bb013dd6c9a9f99L65-R65) [[2]](diffhunk://#diff-11734120d4f63f0c43eaf0c4390fa82c62fd60ecabaac1c96bb013dd6c9a9f99L107-R107) [[3]](diffhunk://#diff-11734120d4f63f0c43eaf0c4390fa82c62fd60ecabaac1c96bb013dd6c9a9f99L138-R149)
  - Added validation to ensure only organizers can update the `status` field.
* **`hackathon/views.py`**: Modified the review creation process to automatically update the submission's `status` to `reviewed` when a new review is added, if the current status is `pending`.

### Organizer Functionality Enhancements:
* **`hackathon/urls.py`**: Added a new endpoint, `/organizer/hackathons/`, for organizers to fetch all hackathons hosted by their organization. [[1]](diffhunk://#diff-df38932dc53aa8e511e2abf87a988b0b74d69de627c3654c8bd5c6b3ff8ea828L7-R7) [[2]](diffhunk://#diff-df38932dc53aa8e511e2abf87a988b0b74d69de627c3654c8bd5c6b3ff8ea828R19)
* **`hackathon/views.py`**: Implemented the `OrganizerHackathonsView` class to handle the new endpoint, including permission checks and data serialization.