### PR TITLE
Added endpoints for skills

### DIFF
--- a/accounts/urls.py
+++ b/accounts/urls.py
@@ -1,4 +1,5 @@
-from django.urls import path
+from django.urls import path, include
+from rest_framework.routers import DefaultRouter
 from .views import (
     UserRegistrationView,
     UserLoginView,
@@ -10,8 +11,14 @@ from .views import (
     ProfileCreateView,
     ProfileRetrieveView,
     ProfileUpdateView,
-    ProfileDeleteView
+    ProfileDeleteView,
+    SkillViewSet,
+    UserSkillsView,
+    HackathonSkillsView
 )
+
+router = DefaultRouter()
+router.register(r'skills', SkillViewSet)
 
 urlpatterns = [
     path('register/', UserRegistrationView.as_view(), name='register'),
@@ -21,8 +28,11 @@ urlpatterns = [
     path('users/<int:user_id>/', UserRetrieveView.as_view(), name='user_retrieve'),
     path('users/<int:user_id>/update/', UserUpdateView.as_view(), name='user_update'),
     path('users/<int:user_id>/delete/', UserDeleteView.as_view(), name='user_delete'),
+    path('users/<int:user_id>/skills/', UserSkillsView.as_view(), name='user_skills'),
     path('profiles/create/', ProfileCreateView.as_view(), name='profile_create'),
     path('profiles/<int:user_id>/', ProfileRetrieveView.as_view(), name='profile_retrieve'),
     path('profiles/<int:user_id>/update/', ProfileUpdateView.as_view(), name='profile_update'),
     path('profiles/<int:user_id>/delete/', ProfileDeleteView.as_view(), name='profile_delete'),
+    path('hackathons/<int:hackathon_id>/skills/', HackathonSkillsView.as_view(), name='hackathon_skills'),
+    path('', include(router.urls)),
 ]


### PR DESCRIPTION
This pull request introduces new functionality for managing and retrieving skills in the `accounts` app. It includes updates to the URL routing, views, and serializers to support skill-related operations. The most significant changes involve the addition of a `SkillViewSet` for CRUD operations on skills and new API endpoints for user and hackathon-specific skills.

### Routing updates:
* Updated `accounts/urls.py` to include a `DefaultRouter` for registering the `SkillViewSet` and added new endpoints for user-specific and hackathon-specific skills. (`[[1]](diffhunk://#diff-03dca5d7540fa101a3ff209d6d035f43b1637d2e6c9fbe9ebfe7342637ac3ca9L1-R2)`, `[[2]](diffhunk://#diff-03dca5d7540fa101a3ff209d6d035f43b1637d2e6c9fbe9ebfe7342637ac3ca9L13-R22)`, `[[3]](diffhunk://#diff-03dca5d7540fa101a3ff209d6d035f43b1637d2e6c9fbe9ebfe7342637ac3ca9R31-R37)`)

### Skill management:
* Added a `SkillViewSet` in `accounts/views.py` to handle CRUD operations on skills with appropriate Swagger documentation for each method. (`[accounts/views.pyR289-R404](diffhunk://#diff-dbd84d60cbc8023306050504e8b3559801fa31ed64b7e967379a5293528b7978R289-R404)`)

### User and hackathon-specific skills:
* Introduced `UserSkillsView` to retrieve all skills associated with a specific user. (`[accounts/views.pyR289-R404](diffhunk://#diff-dbd84d60cbc8023306050504e8b3559801fa31ed64b7e967379a5293528b7978R289-R404)`)
* Added `HackathonSkillsView` to retrieve all skills associated with a specific hackathon. (`[accounts/views.pyR289-R404](diffhunk://#diff-dbd84d60cbc8023306050504e8b3559801fa31ed64b7e967379a5293528b7978R289-R404)`)

### Supporting changes:
* Updated imports in `accounts/views.py` to include `SkillSerializer`, `Skill` model, and relevant DRF classes. (`[accounts/views.pyR4-R9](diffhunk://#diff-dbd84d60cbc8023306050504e8b3559801fa31ed64b7e967379a5293528b7978R4-R9)`)