### PR TITLE
Muritadhor

### DIFF
--- a/hackathon/views.py
+++ b/hackathon/views.py
@@ -366,9 +366,17 @@ class SubmissionViewSet(ModelViewSet):
             return Submission.objects.filter(hackathon_id=hackathon_id)
         return Submission.objects.filter(hackathon_id=hackathon_id, team__members=self.request.user)
 
+    def get_serializer_context(self):
+        context = super().get_serializer_context()
+        hackathon_id = self.kwargs.get('hackathon_id')
+        if hackathon_id:
+            hackathon = Hackathon.objects.get(id=hackathon_id)
+            context['hackathon'] = hackathon
+        return context
+
     def perform_create(self, serializer):
         hackathon = Hackathon.objects.get(id=self.kwargs['hackathon_id'])
-        serializer.save(hackathon=hackathon)
+        serializer.save()
         # Send email notification for submission
         submission = serializer.instance
         send_mail(

--- a/team/models.py
+++ b/team/models.py
@@ -13,15 +13,14 @@ class Team(models.Model):
     def __str__(self):
         return self.name
     
-    @property
-    def projects(self):
+    def get_projects(self):
         return self.projects.all()
     
-    @property
-    def submissions(self):
+    def get_submissions(self):
         return self.submissions.all()
     
-    @property
-    def prizes(self):
-        return self.prizes.all()
+    def get_prizes(self):
+        # Return empty queryset since there's no Prize model related to Team
+        from django.db.models import QuerySet
+        return QuerySet().none()
     

--- a/team/views.py
+++ b/team/views.py
@@ -83,7 +83,7 @@ class CreateHackathonTeamView(GenericAPIView):
         # Send email notifications to all team members
         send_mail(
             subject=f"Team Created for {hackathon.title}",
-            message=f"Dear Team,\n\nA new team '{team.name}' has been created for '{hackathon.title}'.\nTeam Organizer: {team.organizer.get_full_name()}\nMembers: {', '.join([member.get_full_name() for member in team.members.all()])}\n\nGood luck with the hackathon!",
+            message=f"Dear Team,\n\nA new team '{team.name}' has been created for '{hackathon.title}'.\nTeam Organizer: {team.organizer.get_full_name if team.organizer else 'Unknown'}\nMembers: {', '.join([member.get_full_name for member in team.members.all()])}\n\nGood luck with the hackathon!",
             from_email=settings.DEFAULT_FROM_EMAIL,
             recipient_list=[member.email for member in team.members.all()],
             fail_silently=True


### PR DESCRIPTION
This pull request introduces several improvements and fixes to the team and submission creation workflows, focusing on better handling of related objects, validation, and serializer context. The changes ensure that user IDs are properly resolved to user objects, context is passed correctly to serializers, and related model methods are made more explicit. Below are the most important changes grouped by theme.

**Submission Creation & Validation Improvements**

* The `CreateSubmissionSerializer` now validates and resolves the `project` field to an integer ID and ensures the project exists and belongs to the user's team. The submission status is explicitly set to `'pending'` on creation.
* The view handling submission creation (`hackathon/views.py`) now passes the `hackathon` object in the serializer context, allowing serializers to access it directly for validation and creation logic.

**Team Creation & Member Assignment**

* Both `CreateTeamSerializer` and `CreateHackathonTeamSerializer` now accept a list of user IDs for team members, resolving them to user objects before assignment. This prevents issues with passing raw IDs to the `set` method. [[1]](diffhunk://#diff-b8ee57e7fcc9e59f6933800a79b2c0c4ce840e426781548206021ba844750b4fR9-R14) [[2]](diffhunk://#diff-b8ee57e7fcc9e59f6933800a79b2c0c4ce840e426781548206021ba844750b4fL34-R43) [[3]](diffhunk://#diff-b8ee57e7fcc9e59f6933800a79b2c0c4ce840e426781548206021ba844750b4fR166-R170) [[4]](diffhunk://#diff-b8ee57e7fcc9e59f6933800a79b2c0c4ce840e426781548206021ba844750b4fL224-R242)
* When creating a hackathon team, the organizer's participant record is also updated to reflect team membership if not already set, ensuring consistency in participant data.

**Model and Serializer Refactoring**

* Methods in the `Team` model for accessing related objects (`projects`, `submissions`, `prizes`) have been refactored to explicit methods (`get_projects`, `get_submissions`, `get_prizes`). The `get_prizes` method now returns an empty queryset, clarifying that no prize relation exists. Corresponding serializer methods have been updated to use these explicit methods and return empty lists for prizes. [[1]](diffhunk://#diff-5c3a7e12651d9ea35e423d92ad8a5adac8e06f7a9b9c4f46957fe5a664c3a8f2L16-R25) [[2]](diffhunk://#diff-b8ee57e7fcc9e59f6933800a79b2c0c4ce840e426781548206021ba844750b4fL62-R78)

**Email Notification Fix**

* The email notification logic for team creation now safely handles cases where the organizer or members may be missing, using function references instead of method calls to avoid errors.