### PR TITLE
Muritadhor

### DIFF
--- a/hackathon/urls.py
+++ b/hackathon/urls.py
@@ -6,7 +6,7 @@ from .views import (
     SubmissionViewSet, ReviewViewSet, ThemeViewSet, SubmitProjectView, JudgeHackathonsView,
     HackathonJudgesView, HackathonParticipantsView, OrganizerHackathonsView,
     JoinTeamView, HackathonIndividualParticipantsView, AvailableTeamsView,
-    UserRegisteredHackathonsView
+    UserRegisteredHackathonsView, JudgeAllReviewsView
 
 )
 
@@ -20,6 +20,7 @@ urlpatterns = [
     path('create/', HackathonCreateView.as_view(), name='hackathon_create'),
     path('my-registrations/', UserRegisteredHackathonsView.as_view(), name='user_registered_hackathons'),
     path('judge/hackathons/', JudgeHackathonsView.as_view(), name='judge_hackathons'),
+    path('judge/reviews/', JudgeAllReviewsView.as_view(), name='judge_all_reviews'),
     path('organizer/hackathons/', OrganizerHackathonsView.as_view(), name='organizer_hackathons'),
     path('<int:hackathon_id>/', HackathonRetrieveView.as_view(), name='hackathon_retrieve'),
     path('<int:hackathon_id>/judges/', HackathonJudgesView.as_view(), name='hackathon_judges'),

--- a/hackathon/views.py
+++ b/hackathon/views.py
@@ -430,6 +430,24 @@ class ReviewViewSet(ModelViewSet):
         )
 
 
+class JudgeAllReviewsView(APIView):
+    permission_classes = [IsAuthenticated, IsJudge]
+
+    @swagger_auto_schema(
+        responses={
+            200: ReviewSerializer(many=True),
+            401: "Unauthorized",
+            403: "Forbidden"
+        },
+        operation_description="Get all reviews made by the authenticated judge across all hackathons.",
+        tags=['reviews']
+    )
+    def get(self, request):
+        reviews = Review.objects.filter(judge=request.user).select_related('submission__hackathon', 'submission__project', 'submission__team')
+        serializer = ReviewSerializer(reviews, many=True)
+        return Response(serializer.data, status=status.HTTP_200_OK)
+
+
 class ThemeViewSet(ModelViewSet):
     permission_classes = [IsAuthenticated, IsOrganizer]
     serializer_class = ThemeSerializer


### PR DESCRIPTION
This pull request introduces new API endpoints and improves API documentation for hackathon reviews and team management. The main changes include adding an endpoint for judges to view all their reviews across hackathons, and an endpoint for users to retrieve their team for a specific hackathon. Both endpoints are documented with Swagger for better API discoverability and usability.

**New endpoints and API features:**

_Review management:_
* Added `JudgeAllReviewsView` endpoint and corresponding URL route, allowing authenticated judges to retrieve all reviews they have made across all hackathons. This endpoint is documented with Swagger for clear API usage. [[1]](diffhunk://#diff-a45f953071c9f6dc1111be9e09751c9d65e16c40426d9ab1377b2143d3518a6fR433-R450) [[2]](diffhunk://#diff-df38932dc53aa8e511e2abf87a988b0b74d69de627c3654c8bd5c6b3ff8ea828L9-R9) [[3]](diffhunk://#diff-df38932dc53aa8e511e2abf87a988b0b74d69de627c3654c8bd5c6b3ff8ea828R23)

_Team management:_
* Added `by_hackathon` action to the team viewset, providing an endpoint for users to get their team for a specific hackathon by passing a `hackathon_id` query parameter. This endpoint is also documented with Swagger, specifying required parameters and possible responses.

**API documentation improvements:**

* Imported `openapi` from `drf_yasg` to support enhanced Swagger documentation for new endpoints.