### PR TITLE
Muritadhor

### DIFF
--- a/project/views.py
+++ b/project/views.py
@@ -2,8 +2,10 @@ from django.shortcuts import render
 from rest_framework import status
 from rest_framework.response import Response
 from rest_framework.viewsets import ModelViewSet
+from rest_framework.decorators import action
 from rest_framework.permissions import IsAuthenticated
 from drf_yasg.utils import swagger_auto_schema
+from drf_yasg import openapi
 from .serializers import CreateProjectSerializer, ProjectSerializer, UpdateProjectSerializer
 from .models import Project
 
@@ -26,3 +28,74 @@ class ProjectViewSet(ModelViewSet):
     
     def perform_create(self, serializer):
         serializer.save()
+    
+    @swagger_auto_schema(
+        manual_parameters=[
+            openapi.Parameter(
+                'hackathon_id',
+                openapi.IN_QUERY,
+                description='The ID of the hackathon to get the user\'s project for',
+                type=openapi.TYPE_INTEGER,
+                required=True
+            )
+        ],
+        responses={
+            200: ProjectSerializer,
+            400: "Bad Request - hackathon_id parameter required",
+            404: "Not Found - No project found for this hackathon"
+        },
+        operation_description="Get the project that the authenticated user's team submitted to a specific hackathon",
+        tags=['projects']
+    )
+    @action(detail=False, methods=['get'])
+    def by_hackathon(self, request):
+        """Get user's team project for a specific hackathon"""
+        from hackathon.models import Hackathon, Submission
+        from team.models import Team
+        
+        hackathon_id = request.query_params.get('hackathon_id')
+        if not hackathon_id:
+            return Response(
+                {'error': 'hackathon_id parameter is required'}, 
+                status=status.HTTP_400_BAD_REQUEST
+            )
+        
+        try:
+            hackathon_id = int(hackathon_id)
+            hackathon = Hackathon.objects.get(id=hackathon_id)
+        except (ValueError, Hackathon.DoesNotExist):
+            return Response(
+                {'error': 'Invalid hackathon_id or hackathon does not exist'}, 
+                status=status.HTTP_400_BAD_REQUEST
+            )
+        
+        # Find the user's team for this hackathon
+        user_team = Team.objects.filter(
+            members=request.user, 
+            hackathons__id=hackathon_id
+        ).first()
+        
+        if not user_team:
+            return Response(
+                {'error': 'You are not part of any team registered for this hackathon'}, 
+                status=status.HTTP_404_NOT_FOUND
+            )
+        
+        # Find the submission (and thus project) for this team and hackathon
+        try:
+            submission = Submission.objects.get(
+                hackathon=hackathon,
+                team=user_team
+            )
+            project = submission.project
+            
+            return Response(
+                ProjectSerializer(project).data, 
+                status=status.HTTP_200_OK
+            )
+            
+        except Submission.DoesNotExist:
+            return Response(
+                {'error': 'No project has been submitted by your team for this hackathon'}, 
+                status=status.HTTP_404_NOT_FOUND
+            )


### PR DESCRIPTION
This pull request introduces several enhancements and refactors to team and hackathon management, focusing on improving team member management by switching from user IDs to emails, adding a "leave team" feature, and enriching hackathon serialization. It also introduces a new endpoint for retrieving a user's project for a specific hackathon.

**Team member management improvements:**

* Refactored all team member addition, removal, and creation logic to use user emails instead of user IDs. This affects `CreateTeamSerializer`, `AddMemberSerializer`, `RemoveMemberSerializer`, and `CreateHackathonTeamSerializer`, improving usability and validation. [[1]](diffhunk://#diff-b8ee57e7fcc9e59f6933800a79b2c0c4ce840e426781548206021ba844750b4fL10-R12) [[2]](diffhunk://#diff-b8ee57e7fcc9e59f6933800a79b2c0c4ce840e426781548206021ba844750b4fL22-R41) [[3]](diffhunk://#diff-b8ee57e7fcc9e59f6933800a79b2c0c4ce840e426781548206021ba844750b4fR50-R58) [[4]](diffhunk://#diff-b8ee57e7fcc9e59f6933800a79b2c0c4ce840e426781548206021ba844750b4fL106-R123) [[5]](diffhunk://#diff-b8ee57e7fcc9e59f6933800a79b2c0c4ce840e426781548206021ba844750b4fL118-R151) [[6]](diffhunk://#diff-b8ee57e7fcc9e59f6933800a79b2c0c4ce840e426781548206021ba844750b4fL146-R163) [[7]](diffhunk://#diff-b8ee57e7fcc9e59f6933800a79b2c0c4ce840e426781548206021ba844750b4fL189-R251) [[8]](diffhunk://#diff-b8ee57e7fcc9e59f6933800a79b2c0c4ce840e426781548206021ba844750b4fL206-R282) [[9]](diffhunk://#diff-b8ee57e7fcc9e59f6933800a79b2c0c4ce840e426781548206021ba844750b4fR292-R294) [[10]](diffhunk://#diff-b8ee57e7fcc9e59f6933800a79b2c0c4ce840e426781548206021ba844750b4fL239-R306)
* Added the `LeaveTeamSerializer` and corresponding `leave_team` API endpoint, allowing non-organizer team members to leave a team. This also updates hackathon participant records and notifies the remaining team members by email. [[1]](diffhunk://#diff-b8ee57e7fcc9e59f6933800a79b2c0c4ce840e426781548206021ba844750b4fL159-R226) [[2]](diffhunk://#diff-8cbc6bf7382fdf4a8493c5b114ce423a1574253c00e4824eab11e0f2a7c49e6aL10-R10) [[3]](diffhunk://#diff-8cbc6bf7382fdf4a8493c5b114ce423a1574253c00e4824eab11e0f2a7c49e6aR60-R95)

**Hackathon serialization improvements:**

* Enhanced the `HackathonSerializer` to include organization, judges, skills, participants count, and submissions count fields, providing richer hackathon data in API responses.

**Project and hackathon integration:**

* Added a new `by_hackathon` endpoint to the project viewset, allowing users to retrieve their team's project submission for a specific hackathon via a query parameter. [[1]](diffhunk://#diff-183c8af0cd878796ac209f68c60695ed77e14c5e31726229f272a430b43ae2d0R5-R8) [[2]](diffhunk://#diff-183c8af0cd878796ac209f68c60695ed77e14c5e31726229f272a430b43ae2d0R31-R101)

**Code cleanup:**

* Removed unused import of `TeamSerializer` from `hackathon/serializers.py`.