### PR TITLE
Muritadhor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ __pycache__/
 migrations/
 */migrations/
 populate_hackathons.py
+.DS_Store

--- a/hackathon/urls.py
+++ b/hackathon/urls.py
@@ -7,7 +7,7 @@ from .views import (
     HackathonJudgesView, HackathonParticipantsView, OrganizerHackathonsView,
     JoinTeamView, HackathonIndividualParticipantsView, AvailableTeamsView,
     UserRegisteredHackathonsView, JudgeAllReviewsView, HackathonProjectsView,
-    SubmissionProjectDetailView
+    SubmissionProjectDetailView, OrganizationHackathonsView
 
 )
 
@@ -23,6 +23,7 @@ urlpatterns = [
     path('judge/hackathons/', JudgeHackathonsView.as_view(), name='judge_hackathons'),
     path('judge/reviews/', JudgeAllReviewsView.as_view(), name='judge_all_reviews'),
     path('organizer/hackathons/', OrganizerHackathonsView.as_view(), name='organizer_hackathons'),
+    path('organization/<int:organization_id>/hackathons/', OrganizationHackathonsView.as_view(), name='organization_hackathons'),
     path('<int:hackathon_id>/', HackathonRetrieveView.as_view(), name='hackathon_retrieve'),
     path('<int:hackathon_id>/judges/', HackathonJudgesView.as_view(), name='hackathon_judges'),
     path('<int:hackathon_id>/participants/', HackathonParticipantsView.as_view(), name='hackathon_participants'),

--- a/hackathon/views.py
+++ b/hackathon/views.py
@@ -636,6 +636,40 @@ class OrganizerHackathonsView(APIView):
         return Response(serializer.data, status=status.HTTP_200_OK)
 
 
+class OrganizationHackathonsView(APIView):
+
+    def get_permissions(self):
+        # Allow unauthenticated access for viewing public hackathons
+        return []
+
+    @swagger_auto_schema(
+        responses={
+            200: HackathonSerializer(many=True),
+            404: "Organization not found"
+        },
+        operation_description="Fetch all hackathons for a specific organization. No authentication required.",
+        tags=['hackathons']
+    )
+    def get(self, request, organization_id):
+        from organization.models import Organization
+        try:
+            organization = Organization.objects.get(id=organization_id)
+        except Organization.DoesNotExist:
+            return Response({"error": "Organization not found."}, status=status.HTTP_404_NOT_FOUND)
+
+        # Get all hackathons for this organization
+        hackathons = Hackathon.objects.filter(organization=organization)
+        serializer = HackathonSerializer(hackathons, many=True)
+        return Response({
+            "organization": {
+                "id": organization.id,
+                "name": organization.name
+            },
+            "hackathons_count": hackathons.count(),
+            "hackathons": serializer.data
+        }, status=status.HTTP_200_OK)
+
+
 
 
 class JoinTeamView(GenericAPIView):


### PR DESCRIPTION
This pull request introduces a new API endpoint for fetching hackathons by organization and improves review validation logic to prevent duplicate reviews during updates. The main changes are grouped below:

### API Enhancements

* Added the `OrganizationHackathonsView` to allow unauthenticated users to fetch all hackathons for a specific organization, including organization details and hackathon count.
* Registered the new endpoint in `hackathon/urls.py` for accessing organization-specific hackathons. [[1]](diffhunk://#diff-df38932dc53aa8e511e2abf87a988b0b74d69de627c3654c8bd5c6b3ff8ea828R26) [[2]](diffhunk://#diff-df38932dc53aa8e511e2abf87a988b0b74d69de627c3654c8bd5c6b3ff8ea828L10-R10)

### Validation Improvements

* Updated review validation in `hackathon/serializers.py` to ensure that duplicate review checks exclude the current review instance when updating, preventing false positives during review updates.