### PR TITLE
feat: paginated hackathon listing with Redis caching

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ migrations/
 */migrations/
 populate_hackathons.py
 .DS_Store
+vortexis_backend/test_settings.py

--- a/hackathon/tests.py
+++ b/hackathon/tests.py
@@ -1,3 +1,234 @@
-from django.test import TestCase
+from datetime import date, timedelta
 
-# Create your tests here.
+from django.core.cache import cache
+from django.utils import timezone
+from rest_framework import status
+from rest_framework.test import APITestCase
+
+from accounts.models import User
+from organization.models import Organization
+
+from .models import Hackathon
+
+LIST_URL = '/api/v1/hackathon/'
+
+
+def make_user(n=1):
+    return User.objects.create_user(
+        email=f'user{n}@test.com',
+        username=f'user{n}',
+        first_name='Test',
+        last_name='User',
+        password='testpass123',
+    )
+
+
+def make_org(organizer):
+    return Organization.objects.create(
+        name='Test Org',
+        description='A test organization',
+        organizer=organizer,
+        is_approved=True,
+    )
+
+
+def make_hackathon(org, title='Hackathon', active=True, visible=True, offset_days=0):
+    today = date.today()
+    future = today + timedelta(days=30)
+    past_end = today - timedelta(days=1)
+    deadline = timezone.now() + timedelta(days=30)
+
+    end = future if active else past_end
+    return Hackathon.objects.create(
+        title=title,
+        description='Test description',
+        venue='Online',
+        visibility=visible,
+        start_date=today - timedelta(days=offset_days),
+        end_date=end,
+        submission_deadline=deadline if active else timezone.now() - timedelta(days=1),
+        organization=org,
+        grand_prize=1000,
+    )
+
+
+class HackathonListPaginationTests(APITestCase):
+
+    def setUp(self):
+        cache.clear()
+        self.organizer = make_user(1)
+        self.org = make_org(self.organizer)
+        today = date.today()
+        future = today + timedelta(days=30)
+        deadline = timezone.now() + timedelta(days=30)
+
+        # 12 active visible hackathons — created in order so created_at is ascending
+        for i in range(12):
+            Hackathon.objects.create(
+                title=f'Active Hackathon {i + 1:02d}',
+                description='Test',
+                venue='Online',
+                visibility=True,
+                start_date=today,
+                end_date=future,
+                submission_deadline=deadline,
+                organization=self.org,
+            )
+
+        # Ended hackathon — should be excluded from active list
+        Hackathon.objects.create(
+            title='Ended Hackathon',
+            description='Test',
+            venue='Online',
+            visibility=True,
+            start_date=today - timedelta(days=10),
+            end_date=today - timedelta(days=1),
+            submission_deadline=timezone.now() - timedelta(days=1),
+            organization=self.org,
+        )
+
+        # Private hackathon — should be excluded
+        Hackathon.objects.create(
+            title='Private Hackathon',
+            description='Test',
+            venue='Online',
+            visibility=False,
+            start_date=today,
+            end_date=future,
+            submission_deadline=deadline,
+            organization=self.org,
+        )
+
+    # --- Default pagination ---
+
+    def test_default_returns_paginated_response_shape(self):
+        response = self.client.get(LIST_URL)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        body = response.json()
+        self.assertIn('data', body)
+        self.assertIn('pagination', body)
+        pagination = body['pagination']
+        self.assertIn('page', pagination)
+        self.assertIn('pageSize', pagination)
+        self.assertIn('totalItems', pagination)
+        self.assertIn('totalPages', pagination)
+
+    def test_default_page_size_is_ten(self):
+        response = self.client.get(LIST_URL)
+        body = response.json()
+        self.assertEqual(len(body['data']), 10)
+        self.assertEqual(body['pagination']['pageSize'], 10)
+
+    def test_total_items_counts_only_active_visible_hackathons(self):
+        response = self.client.get(LIST_URL)
+        body = response.json()
+        self.assertEqual(body['pagination']['totalItems'], 12)
+
+    def test_total_pages_calculation(self):
+        response = self.client.get(LIST_URL)
+        body = response.json()
+        self.assertEqual(body['pagination']['totalPages'], 2)
+
+    def test_default_is_page_one(self):
+        response = self.client.get(LIST_URL)
+        self.assertEqual(response.json()['pagination']['page'], 1)
+
+    # --- Custom page / pageSize ---
+
+    def test_custom_page_size(self):
+        response = self.client.get(LIST_URL, {'page': 1, 'pageSize': 5})
+        body = response.json()
+        self.assertEqual(len(body['data']), 5)
+        self.assertEqual(body['pagination']['pageSize'], 5)
+        self.assertEqual(body['pagination']['totalPages'], 3)
+
+    def test_page_two_returns_remaining_items(self):
+        response = self.client.get(LIST_URL, {'page': 2, 'pageSize': 10})
+        body = response.json()
+        self.assertEqual(len(body['data']), 2)
+        self.assertEqual(body['pagination']['page'], 2)
+
+    def test_page_two_items_differ_from_page_one(self):
+        page1 = self.client.get(LIST_URL, {'page': 1, 'pageSize': 10}).json()['data']
+        page2 = self.client.get(LIST_URL, {'page': 2, 'pageSize': 10}).json()['data']
+        ids_page1 = {h['id'] for h in page1}
+        ids_page2 = {h['id'] for h in page2}
+        self.assertTrue(ids_page1.isdisjoint(ids_page2))
+
+    def test_out_of_range_page_returns_empty_data(self):
+        response = self.client.get(LIST_URL, {'page': 999})
+        body = response.json()
+        self.assertEqual(body['data'], [])
+        self.assertEqual(body['pagination']['totalItems'], 12)
+
+    # --- limit param ---
+
+    def test_limit_returns_correct_count(self):
+        response = self.client.get(LIST_URL, {'limit': 4})
+        body = response.json()
+        self.assertIn('data', body)
+        self.assertEqual(len(body['data']), 4)
+
+    def test_limit_response_has_no_pagination_block(self):
+        response = self.client.get(LIST_URL, {'limit': 4})
+        body = response.json()
+        self.assertNotIn('pagination', body)
+        self.assertEqual(body['limit'], 4)
+
+    def test_limit_larger_than_total_returns_all_active(self):
+        response = self.client.get(LIST_URL, {'limit': 100})
+        body = response.json()
+        self.assertEqual(len(body['data']), 12)
+
+    def test_limit_of_one_returns_single_item(self):
+        response = self.client.get(LIST_URL, {'limit': 1})
+        body = response.json()
+        self.assertEqual(len(body['data']), 1)
+
+    def test_invalid_string_limit_returns_400(self):
+        response = self.client.get(LIST_URL, {'limit': 'abc'})
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_negative_limit_returns_400(self):
+        response = self.client.get(LIST_URL, {'limit': -1})
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_zero_limit_returns_400(self):
+        response = self.client.get(LIST_URL, {'limit': 0})
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    # --- Filtering ---
+
+    def test_ended_hackathons_excluded(self):
+        response = self.client.get(LIST_URL, {'limit': 100})
+        titles = [h['title'] for h in response.json()['data']]
+        self.assertNotIn('Ended Hackathon', titles)
+
+    def test_private_hackathons_excluded(self):
+        response = self.client.get(LIST_URL, {'limit': 100})
+        titles = [h['title'] for h in response.json()['data']]
+        self.assertNotIn('Private Hackathon', titles)
+
+    # --- Ordering ---
+
+    def test_results_ordered_newest_first(self):
+        response = self.client.get(LIST_URL, {'limit': 100})
+        items = response.json()['data']
+        for i in range(len(items) - 1):
+            self.assertGreaterEqual(items[i]['created_at'], items[i + 1]['created_at'])
+
+    def test_limit_returns_most_recent_items(self):
+        # The 12th hackathon created is the most recent; limit=1 should return it
+        all_response = self.client.get(LIST_URL, {'limit': 100})
+        all_items = all_response.json()['data']
+        most_recent_id = all_items[0]['id']
+
+        limit_response = self.client.get(LIST_URL, {'limit': 1})
+        self.assertEqual(limit_response.json()['data'][0]['id'], most_recent_id)
+
+    # --- Auth ---
+
+    def test_list_is_accessible_without_authentication(self):
+        self.client.logout()
+        response = self.client.get(LIST_URL)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)

--- a/hackathon/views.py
+++ b/hackathon/views.py
@@ -1,13 +1,17 @@
+import math
 from rest_framework import status
 from rest_framework.response import Response
 from rest_framework.generics import GenericAPIView, ListCreateAPIView, RetrieveUpdateDestroyAPIView
 from rest_framework.viewsets import ModelViewSet
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.pagination import PageNumberPagination
+from rest_framework.exceptions import NotFound
 from accounts.permissions import IsOrganizer, IsJudge
 from accounts.serializers import UserSerializer
 from django.conf import settings
 from django.utils import timezone
+from django.utils.decorators import method_decorator
+from django.views.decorators.cache import cache_page
 from drf_yasg.utils import swagger_auto_schema
 from rest_framework.views import APIView
 from drf_yasg import openapi
@@ -73,6 +77,7 @@ class HackathonPagination(PageNumberPagination):
     max_page_size = 100
 
 
+@method_decorator(cache_page(60 * 5), name='get')
 class HackathonListView(ListCreateAPIView):
     serializer_class = HackathonSerializer
 
@@ -120,7 +125,21 @@ class HackathonListView(ListCreateAPIView):
             return Response({"data": data, "limit": limit})
 
         paginator = HackathonPagination()
-        page = paginator.paginate_queryset(queryset, request)
+        try:
+            page = paginator.paginate_queryset(queryset, request)
+        except NotFound:
+            total = queryset.count()
+            page_size = paginator.get_page_size(request)
+            return Response({
+                "data": [],
+                "pagination": {
+                    "page": int(request.query_params.get(paginator.page_query_param, 1)),
+                    "pageSize": page_size,
+                    "totalItems": total,
+                    "totalPages": math.ceil(total / page_size) if total else 1,
+                }
+            })
+
         serializer = self.get_serializer(page, many=True)
         return Response({
             "data": serializer.data,
@@ -133,6 +152,7 @@ class HackathonListView(ListCreateAPIView):
         })
 
 
+@method_decorator(cache_page(60 * 5), name='get')
 class HackathonRetrieveView(RetrieveUpdateDestroyAPIView):
     serializer_class = HackathonSerializer
     lookup_field = 'id'
@@ -732,10 +752,10 @@ class OrganizerHackathonsView(APIView):
         return Response(serializer.data, status=status.HTTP_200_OK)
 
 
+@method_decorator(cache_page(60 * 5), name='get')
 class OrganizationHackathonsView(APIView):
 
     def get_permissions(self):
-        # Allow unauthenticated access for viewing public hackathons
         return []
 
     @swagger_auto_schema(

--- a/hackathon/views.py
+++ b/hackathon/views.py
@@ -3,6 +3,7 @@ from rest_framework.response import Response
 from rest_framework.generics import GenericAPIView, ListCreateAPIView, RetrieveUpdateDestroyAPIView
 from rest_framework.viewsets import ModelViewSet
 from rest_framework.permissions import IsAuthenticated
+from rest_framework.pagination import PageNumberPagination
 from accounts.permissions import IsOrganizer, IsJudge
 from accounts.serializers import UserSerializer
 from django.conf import settings
@@ -65,35 +66,71 @@ class HackathonCreateView(GenericAPIView):
         )
 
 
+class HackathonPagination(PageNumberPagination):
+    page_size = 10
+    page_size_query_param = 'pageSize'
+    page_query_param = 'page'
+    max_page_size = 100
+
+
 class HackathonListView(ListCreateAPIView):
     serializer_class = HackathonSerializer
 
     def get_queryset(self):
+        today = timezone.now().date()
         return Hackathon.objects.filter(
-            visibility=True
+            visibility=True,
+            end_date__gte=today
         ).select_related(
             'organization', 'organization__organizer'
         ).prefetch_related(
             'themes', 'skills', 'judges'
-        ).order_by('-created_at')  # Latest first
+        ).order_by('-created_at')
 
     def get_permissions(self):
         if self.request.method == 'GET':
-            # Allow unauthenticated access for listing hackathons
             return []
-        else:
-            # Require authentication for creating hackathons
-            return [IsAuthenticated()]
+        return [IsAuthenticated()]
 
     @swagger_auto_schema(
-        responses={
-            200: HackathonSerializer(many=True)
-        },
-        operation_description="List all public hackathons. No authentication required.",
+        manual_parameters=[
+            openapi.Parameter('page', openapi.IN_QUERY, description="Page number (default: 1)", type=openapi.TYPE_INTEGER),
+            openapi.Parameter('pageSize', openapi.IN_QUERY, description="Items per page (default: 10, max: 100)", type=openapi.TYPE_INTEGER),
+            openapi.Parameter('limit', openapi.IN_QUERY, description="Return N most recent active hackathons, bypasses page metadata", type=openapi.TYPE_INTEGER),
+        ],
+        responses={200: HackathonSerializer(many=True), 400: "Bad Request"},
+        operation_description="List active public hackathons. Use page/pageSize for pagination or limit for a simple count. No authentication required.",
         tags=['hackathons']
     )
     def get(self, request, *args, **kwargs):
-        return super().get(request, *args, **kwargs)
+        queryset = self.get_queryset()
+
+        limit = request.query_params.get('limit')
+        if limit is not None:
+            try:
+                limit = int(limit)
+                if limit < 1:
+                    raise ValueError
+            except ValueError:
+                return Response(
+                    {"error": "limit must be a positive integer."},
+                    status=status.HTTP_400_BAD_REQUEST
+                )
+            data = self.get_serializer(queryset[:limit], many=True).data
+            return Response({"data": data, "limit": limit})
+
+        paginator = HackathonPagination()
+        page = paginator.paginate_queryset(queryset, request)
+        serializer = self.get_serializer(page, many=True)
+        return Response({
+            "data": serializer.data,
+            "pagination": {
+                "page": paginator.page.number,
+                "pageSize": paginator.get_page_size(request),
+                "totalItems": paginator.page.paginator.count,
+                "totalPages": paginator.page.paginator.num_pages,
+            }
+        })
 
 
 class HackathonRetrieveView(RetrieveUpdateDestroyAPIView):


### PR DESCRIPTION
### What changed

GET `/api/v1/hackathon/ ` previously returned every hackathon in a single unfiltered dump with no pagination and no caching — every request hit the database and returned stale or irrelevant (ended/private) hackathons.

**Changes** - [hackathon/views.py](https://github.com/Michael-Nwachukwu/Vortexis-Backend/blob/ceccac974df9f59b9d91bd161846bd462c5d2894/hackathon/views.py)

Added 

1. HackathonPagination class (page, pageSize, max 100)
2. Active filter — list now only returns hackathons where visibility=True AND end_date >= today; completed hackathons are excluded
3. Pagination mode — ?page=1&pageSize=10 returns paginated results with a pagination metadata block (page, pageSize, totalItems, totalPages)
4. Limit mode — ?limit=N returns the N most recent active hackathons with no metadata overhead
5. Out-of-range pages return data: [] with correct totals instead of a 404
6. Invalid limit values (non-integer, zero, negative) return 400
7. Added @method_decorator(cache_page(300)) to HackathonListView, HackathonRetrieveView, and OrganizationHackathonsView — responses are cached in Redis for 5 minutes per unique URL; only GET is cached, writes are unaffected
8. Updated Swagger docs with page, pageSize, and limit query param definitions

[hackathon/tests.py](https://github.com/Michael-Nwachukwu/Vortexis-Backend/blob/ceccac974df9f59b9d91bd161846bd462c5d2894/hackathon/tests.py)

1. 21 tests covering: response shape, default page size, custom page/pageSize, non-overlapping pages, out-of-range page, limit mode, oversized limit, invalid limit values, ended/private hackathon exclusion, newest-first ordering, and unauthenticated access

Response format
Paginated:

```
{
  "data": [...],
  "pagination": {
    "page": 1,
    "pageSize": 10,
    "totalItems": 42,
    "totalPages": 5
  }
}
Limit:


{
  "data": [...],
  "limit": 4
}
```

Test results

Ran 21 tests in 2.836s — OK