### PR TITLE
fix: remove password exposure from admin user serializer

### DIFF
--- a/admin_console/serializers.py
+++ b/admin_console/serializers.py
@@ -6,10 +6,17 @@ from .models import AuditLog, PlatformSetting
 
 class UserSerializer(serializers.ModelSerializer):
     organizations = serializers.SerializerMethodField()
+
     class Meta:
         model = User
-        fields = '__all__'
+        fields = [
+            'id', 'email', 'username', 'first_name', 'last_name',
+            'auth_provider', 'is_participant', 'is_organizer', 'is_judge',
+            'is_moderator', 'is_admin', 'is_staff', 'is_active', 'is_verified',
+            'date_joined', 'last_login', 'organizations',
+        ]
         ref_name = 'AdminUserSerializer'
+
     def get_organizations(self, obj):
         return list(obj.organizations.values_list('id', flat=True))
     


### PR DESCRIPTION
**Problem**
The admin user listing endpoint `(GET /api/v1/console/users/)` was returning the hashed password, along with `groups` and `user_permissions`, in every response. This was caused by `fields = '__all__'` on the `UserSerializer` in `admin_console/serializers.py.`

**Fix**
Replaced `fields = '__all__'` with an explicit field list, excluding password, groups, user_permissions, and is_superuser.

**Affected file**
`admin_console/serializers.py`