### PR TITLE
fix: repair GitHub OAuth login for private emails and missing names

### DIFF
--- a/accounts/managers.py
+++ b/accounts/managers.py
@@ -10,7 +10,7 @@ class UserManager(BaseUserManager):
         except ValidationError:
             raise ValueError(_('Please enter a valid email address.'))
         
-    def create_user(self, email, username, first_name, last_name, password=None, **extra_fields):
+    def create_user(self, email, username, first_name, last_name='', password=None, **extra_fields):
         if not email:
             raise ValueError(_('Please enter an email address.'))
         self.email_validator(email)
@@ -18,8 +18,9 @@ class UserManager(BaseUserManager):
             raise ValueError(_('Please enter a username.'))
         if not first_name:
             raise ValueError(_('Please enter your first name.'))
-        if not last_name:
-            raise ValueError(_('Please enter your last name.'))
+        # last_name is optional — the model allows blank/null and social
+        # providers (e.g. GitHub) often supply only a single name.
+        last_name = last_name or ''
         email = self.normalize_email(email)
         user = self.model(email=email, username=username, first_name=first_name, last_name=last_name, **extra_fields)
         user.set_password(password)

--- a/social_auth/serializer.py
+++ b/social_auth/serializer.py
@@ -29,23 +29,36 @@ class GithubSocialAuthSerializer(serializers.Serializer):
     def validate(self, attrs):
         code = attrs.get('code')
         access_token = Github.get_token(code)
-        if access_token:
-            github_user = Github.get_user_details(access_token)
-            full_name = github_user.get('name', '')
-            email = github_user.get('email')
-            if not email:
-                raise AuthenticationFailed(detail='Email is required')
-            names = full_name.split(' ') if full_name else ['', '']
-            if len(names) > 1:
-                first_name = names[0]
-                last_name = ' '.join(names[1:])
-            else:
-                first_name = names[0] if names else ''
-                last_name = ''
-            username = github_user.get('login')
-            provider = 'github'
-            user_data = register_social_user(provider, username, email, first_name, last_name)
-            attrs['user_data'] = user_data
-            return attrs
-        else:
+        if not access_token:
             raise AuthenticationFailed(detail='Invalid code')
+
+        github_user = Github.get_user_details(access_token)
+        username = github_user.get('login')
+
+        # GitHub returns email: null when the user keeps it private — fall back
+        # to the /user/emails endpoint for their primary verified address.
+        email = github_user.get('email')
+        if not email:
+            email = Github.get_primary_email(access_token)
+        if not email:
+            raise serializers.ValidationError(
+                {'email': 'Could not retrieve a verified email from GitHub. '
+                          'Please make an email public or grant email access.'}
+            )
+
+        # GitHub's name is a single optional string — may be missing, a single
+        # name, or "First Last". Split safely and fall back to the login.
+        full_name = (github_user.get('name') or '').strip()
+        parts = full_name.split(' ', 1) if full_name else []
+        first_name = parts[0] if parts and parts[0] else (username or 'githubuser')
+        last_name = parts[1] if len(parts) > 1 else ''
+
+        provider = 'github'
+        try:
+            user_data = register_social_user(provider, username, email, first_name, last_name)
+        except ValueError as e:
+            # Surface manager-level validation failures as 400, not a 500 crash.
+            raise serializers.ValidationError({'detail': str(e)})
+
+        attrs['user_data'] = user_data
+        return attrs

--- a/social_auth/tests.py
+++ b/social_auth/tests.py
@@ -1,3 +1,198 @@
-from django.test import TestCase
+from unittest.mock import MagicMock, patch
 
-# Create your tests here.
+from django.test import SimpleTestCase
+from rest_framework import status
+from rest_framework.test import APITestCase
+
+from accounts.models import User
+from social_auth.utils import Github
+
+GITHUB_URL = '/api/v1/auth/github'
+
+
+class GithubGetPrimaryEmailTests(SimpleTestCase):
+    """Unit tests for the /user/emails parsing itself (no DB, no HTTP)."""
+
+    def _mock_get(self, payload):
+        resp = MagicMock()
+        resp.json.return_value = payload
+        return resp
+
+    @patch('social_auth.utils.requests.get')
+    def test_picks_primary_verified(self, mock_get):
+        mock_get.return_value = self._mock_get([
+            {'email': 'secondary@x.com', 'primary': False, 'verified': True},
+            {'email': 'primary@x.com', 'primary': True, 'verified': True},
+        ])
+        self.assertEqual(Github.get_primary_email('tok'), 'primary@x.com')
+
+    @patch('social_auth.utils.requests.get')
+    def test_skips_unverified_primary_uses_verified(self, mock_get):
+        mock_get.return_value = self._mock_get([
+            {'email': 'primary@x.com', 'primary': True, 'verified': False},
+            {'email': 'verified@x.com', 'primary': False, 'verified': True},
+        ])
+        self.assertEqual(Github.get_primary_email('tok'), 'verified@x.com')
+
+    @patch('social_auth.utils.requests.get')
+    def test_none_when_nothing_verified(self, mock_get):
+        mock_get.return_value = self._mock_get([
+            {'email': 'a@x.com', 'primary': True, 'verified': False},
+        ])
+        self.assertIsNone(Github.get_primary_email('tok'))
+
+    @patch('social_auth.utils.requests.get')
+    def test_none_on_error_payload(self, mock_get):
+        # GitHub returns a dict (not a list) on auth failure
+        mock_get.return_value = self._mock_get({'message': 'Bad credentials'})
+        self.assertIsNone(Github.get_primary_email('tok'))
+
+    @patch('social_auth.utils.requests.get', side_effect=Exception('network down'))
+    def test_none_on_request_exception(self, mock_get):
+        self.assertIsNone(Github.get_primary_email('tok'))
+
+
+class GithubSocialAuthTests(APITestCase):
+    """GitHub OAuth registration/login flow.
+
+    The GitHub HTTP calls are mocked so these run without network access. We
+    patch the three points of contact with GitHub:
+      - Github.get_token        -> exchanges the code for an access token
+      - Github.get_user_details -> GET /user
+      - Github.get_primary_email-> GET /user/emails (private-email fallback)
+    """
+
+    def _post(self, code='valid-code'):
+        return self.client.post(GITHUB_URL, {'code': code})
+
+    # --- Bug 1: private emails fall back to /user/emails -----------------
+
+    @patch('social_auth.serializer.Github.get_primary_email')
+    @patch('social_auth.serializer.Github.get_user_details')
+    @patch('social_auth.serializer.Github.get_token')
+    def test_private_email_falls_back_to_user_emails(self, mock_token, mock_user, mock_email):
+        mock_token.return_value = 'gho_token'
+        # GitHub returns email: null for a private email
+        mock_user.return_value = {'login': 'octocat', 'name': 'Mona Cat', 'email': None}
+        mock_email.return_value = 'mona@private.example.com'
+
+        response = self._post()
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        mock_email.assert_called_once()
+        user = User.objects.get(email='mona@private.example.com')
+        self.assertEqual(user.username, 'octocat')
+        self.assertEqual(user.first_name, 'Mona')
+        self.assertEqual(user.last_name, 'Cat')
+
+    @patch('social_auth.serializer.Github.get_primary_email')
+    @patch('social_auth.serializer.Github.get_user_details')
+    @patch('social_auth.serializer.Github.get_token')
+    def test_public_email_does_not_need_fallback(self, mock_token, mock_user, mock_email):
+        mock_token.return_value = 'gho_token'
+        mock_user.return_value = {'login': 'octocat', 'name': 'Mona Cat', 'email': 'mona@public.example.com'}
+
+        response = self._post()
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        mock_email.assert_not_called()
+        self.assertTrue(User.objects.filter(email='mona@public.example.com').exists())
+
+    @patch('social_auth.serializer.Github.get_primary_email')
+    @patch('social_auth.serializer.Github.get_user_details')
+    @patch('social_auth.serializer.Github.get_token')
+    def test_no_email_anywhere_returns_400(self, mock_token, mock_user, mock_email):
+        mock_token.return_value = 'gho_token'
+        mock_user.return_value = {'login': 'octocat', 'name': 'Mona Cat', 'email': None}
+        mock_email.return_value = None
+
+        response = self._post()
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn('email', response.json())
+
+    # --- Bug 2: missing/partial names must not 500 -----------------------
+
+    @patch('social_auth.serializer.Github.get_user_details')
+    @patch('social_auth.serializer.Github.get_token')
+    def test_no_name_falls_back_to_login(self, mock_token, mock_user):
+        mock_token.return_value = 'gho_token'
+        mock_user.return_value = {'login': 'octocat', 'name': None, 'email': 'a@example.com'}
+
+        response = self._post()
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        user = User.objects.get(email='a@example.com')
+        self.assertEqual(user.first_name, 'octocat')
+        self.assertEqual(user.last_name, '')
+
+    @patch('social_auth.serializer.Github.get_user_details')
+    @patch('social_auth.serializer.Github.get_token')
+    def test_single_name_leaves_last_name_empty(self, mock_token, mock_user):
+        mock_token.return_value = 'gho_token'
+        mock_user.return_value = {'login': 'octocat', 'name': 'Mona', 'email': 'b@example.com'}
+
+        response = self._post()
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        user = User.objects.get(email='b@example.com')
+        self.assertEqual(user.first_name, 'Mona')
+        self.assertEqual(user.last_name, '')
+
+    @patch('social_auth.serializer.Github.get_user_details')
+    @patch('social_auth.serializer.Github.get_token')
+    def test_multipart_last_name_is_preserved(self, mock_token, mock_user):
+        mock_token.return_value = 'gho_token'
+        mock_user.return_value = {'login': 'octocat', 'name': 'Mona Lisa Cat', 'email': 'c@example.com'}
+
+        response = self._post()
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        user = User.objects.get(email='c@example.com')
+        self.assertEqual(user.first_name, 'Mona')
+        self.assertEqual(user.last_name, 'Lisa Cat')
+
+    @patch('social_auth.serializer.Github.get_user_details')
+    @patch('social_auth.serializer.Github.get_token')
+    def test_whitespace_only_name_falls_back_to_login(self, mock_token, mock_user):
+        mock_token.return_value = 'gho_token'
+        mock_user.return_value = {'login': 'octocat', 'name': '   ', 'email': 'd@example.com'}
+
+        response = self._post()
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        user = User.objects.get(email='d@example.com')
+        self.assertEqual(user.first_name, 'octocat')
+        self.assertEqual(user.last_name, '')
+
+    # --- Bug 3: invalid code is an auth failure (not a 500) --------------
+
+    @patch('social_auth.serializer.Github.get_token')
+    def test_invalid_code_returns_401(self, mock_token):
+        mock_token.return_value = None
+
+        response = self._post(code='bad-code')
+
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+
+    def test_missing_code_returns_400(self):
+        response = self.client.post(GITHUB_URL, {})
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    # --- Existing-user linking ------------------------------------------
+
+    @patch('social_auth.serializer.Github.get_user_details')
+    @patch('social_auth.serializer.Github.get_token')
+    def test_existing_email_logs_in_without_duplicate(self, mock_token, mock_user):
+        existing = User.objects.create_user(
+            email='dupe@example.com', username='existing',
+            first_name='Old', last_name='Name', password='pw12345',
+        )
+        mock_token.return_value = 'gho_token'
+        mock_user.return_value = {'login': 'existing', 'name': 'Mona Cat', 'email': 'dupe@example.com'}
+
+        response = self._post()
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(User.objects.filter(email='dupe@example.com').count(), 1)
+        self.assertEqual(response.json()['id'], existing.id)

--- a/social_auth/utils.py
+++ b/social_auth/utils.py
@@ -114,4 +114,30 @@ class Github:
             return response.json()
         except Exception as e:
             raise AuthenticationFailed('Invalid or expired token')
+
+    @staticmethod
+    def get_primary_email(access_token):
+        """Fetch the user's primary, verified email.
+
+        GitHub returns ``email: null`` from /user when the user has set their
+        email to private, so we fall back to the /user/emails endpoint and pick
+        the primary verified address.
+        """
+        try:
+            headers = {
+                'Authorization': f'Bearer {access_token}'
+            }
+            response = requests.get('https://api.github.com/user/emails', headers=headers)
+            emails = response.json()
+        except Exception:
+            return None
+
+        if not isinstance(emails, list):
+            return None
+
+        # Prefer the primary + verified address, then any verified address.
+        primary = next((e['email'] for e in emails if e.get('primary') and e.get('verified')), None)
+        if primary:
+            return primary
+        return next((e['email'] for e in emails if e.get('verified')), None)
     


### PR DESCRIPTION
## Summary

GitHub login failed for two common account shapes. Fixes all three issues reported by the frontend:

- **Private emails (was 401 "Email is required").** GitHub returns `email: null` when a user keeps their email private. We only read `/user`, so login failed. Added a fallback to `/user/emails` that picks the primary verified address.
- **Missing / partial names (was 500 crash).** GitHub's `name` is a single optional string — users may have no name, one name, or no last name. `create_user` raised an uncaught `ValueError` on an empty `last_name`. Made `last_name` optional (the model column is already `blank=True, null=True` and regular registration already passes `''`), and the name is now split safely with a fallback to the GitHub login.
- **Validation errors returned 500.** Missing-data cases now return **400** with a clear message; a bad OAuth `code` correctly stays **401**.

## Changes

| File | Change |
|---|---|
| `accounts/managers.py` | `create_user` — `last_name` now optional, defaults to `''` |
| `social_auth/utils.py` | New `Github.get_primary_email()` — `/user/emails` fallback for private emails |
| `social_auth/serializer.py` | Email fallback, safe name split (login fallback), `ValueError → 400` |
| `social_auth/tests.py` | 15 tests (mocked GitHub HTTP) |

## Test plan

- [x] Private email → falls back to `/user/emails`, login succeeds
- [x] Public email → no fallback call needed
- [x] No verified email anywhere → 400 with `email` error
- [x] No name → falls back to GitHub login, empty last name
- [x] Single name / multi-part last name / whitespace-only name handled
- [x] `get_primary_email` parsing: primary+verified, unverified-primary skip, none-verified, error payload, network exception
- [x] Invalid `code` → 401; missing `code` → 400
- [x] Existing email → logs in, no duplicate user

15/15 passing.